### PR TITLE
Add ccache support

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -153,15 +153,15 @@ build_pi_kernel() {
 
         make clean
 
-        yes "" | KERNEL=${KERNEL} ARCH=${ARCH} CROSS_COMPILE=${CROSS_COMPILE} make oldconfig || exit 1
+        yes "" | KERNEL=${KERNEL} ARCH=${ARCH} CROSS_COMPILE="ccache ${CROSS_COMPILE}" make oldconfig || exit 1
 
-        KERNEL=${KERNEL} ARCH=${ARCH} CROSS_COMPILE=${CROSS_COMPILE} make -j $J_CORES zImage modules dtbs || exit 1
+        KERNEL=${KERNEL} ARCH=${ARCH} CROSS_COMPILE="ccache ${CROSS_COMPILE}" KBUILD_BUILD_TIMESTAMP='' make -j $J_CORES zImage modules dtbs || exit 1
 
         echo "Copy kernel"
         cp arch/arm/boot/zImage "${PACKAGE_DIR}/usr/local/share/openhd/kernel/${KERNEL}.img" || exit 1
 
         echo "Copy kernel modules"
-        make -j $J_CORES ARCH=${ARCH} CROSS_COMPILE=${CROSS_COMPILE}  INSTALL_MOD_PATH="${PACKAGE_DIR}" modules_install || exit 1
+        make -j $J_CORES ARCH=${ARCH} CROSS_COMPILE=${CROSS_COMPILE} INSTALL_MOD_PATH="${PACKAGE_DIR}" modules_install || exit 1
 
         echo "Copy DTBs"
         sudo cp arch/arm/boot/dts/*.dtb "${PACKAGE_DIR}/usr/local/share/openhd/kernel/dtb/" || exit 1
@@ -175,14 +175,14 @@ build_pi_kernel() {
 
     pushd rtl8812au
         make clean
-        ARCH=${ARCH} CROSS_COMPILE=${CROSS_COMPILE} make KSRC=${LINUX_DIR} -j $J_CORES M=$(pwd) modules || exit 1
+        ARCH=${ARCH} CROSS_COMPILE="${CROSS_COMPILE}" make KSRC=${LINUX_DIR} -j $J_CORES M=$(pwd) modules || exit 1
         mkdir -p ${PACKAGE_DIR}/lib/modules/${KERNEL_VERSION}/kernel/drivers/net/wireless/realtek/rtl8812au
         install -p -m 644 88XXau.ko "${PACKAGE_DIR}/lib/modules/${KERNEL_VERSION}/kernel/drivers/net/wireless/realtek/rtl8812au/" || exit 1
     popd
 
     pushd rtl88x2bu
         make clean
-        ARCH=${ARCH} CROSS_COMPILE=${CROSS_COMPILE} make KSRC=${LINUX_DIR} -j $J_CORES M=$(pwd) modules || exit 1
+        ARCH=${ARCH} CROSS_COMPILE="${CROSS_COMPILE}" make KSRC=${LINUX_DIR} -j $J_CORES M=$(pwd) modules || exit 1
         mkdir -p ${PACKAGE_DIR}/lib/modules/${KERNEL_VERSION}/kernel/drivers/net/wireless/realtek/rtl88x2bu
         install -p -m 644 88x2bu.ko "${PACKAGE_DIR}/lib/modules/${KERNEL_VERSION}/kernel/drivers/net/wireless/realtek/rtl88x2bu/" || exit 1
     popd


### PR DESCRIPTION
I removed the ccache from the realtek drivers, because it was failing like this:

```
  Building modules, stage 2.
  MODPOST 1 modules
  CC      /home/build/workspace/OpenHD/OpenHDKernelBuilder/rtl8812au/88XXau.mod.o
  LD [M]  /home/build/workspace/OpenHD/OpenHDKernelBuilder/rtl8812au/88XXau.ko
make[1]: Leaving directory '/home/build/workspace/OpenHD/OpenHDKernelBuilder/linux-pi'
/home/build/workspace/OpenHD/OpenHDKernelBuilder
/home/build/workspace/OpenHD/OpenHDKernelBuilder/rtl88x2bu /home/build/workspace/OpenHD/OpenHDKernelBuilder
#make -C /lib/modules/5.4.0-40-generic/build M=/home/build/workspace/OpenHD/OpenHDKernelBuilder/rtl88x2bu clean
cd hal ; rm -fr */*/*/*.mod.c */*/*/*.mod */*/*/*.o */*/*/.*.cmd */*/*/*.ko
cd hal ; rm -fr */*/*.mod.c */*/*.mod */*/*.o */*/.*.cmd */*/*.ko
cd hal ; rm -fr */*.mod.c */*.mod */*.o */.*.cmd */*.ko
cd hal ; rm -fr *.mod.c *.mod *.o .*.cmd *.ko
cd core ; rm -fr */*.mod.c */*.mod */*.o */.*.cmd */*.ko
cd core ; rm -fr *.mod.c *.mod *.o .*.cmd *.ko
cd os_dep/linux ; rm -fr *.mod.c *.mod *.o .*.cmd *.ko
cd os_dep ; rm -fr *.mod.c *.mod *.o .*.cmd *.ko
cd platform ; rm -fr *.mod.c *.mod *.o .*.cmd *.ko
rm -fr Module.symvers ; rm -fr Module.markers ; rm -fr modules.order
rm -fr *.mod.c *.mod *.o .*.cmd *.ko *~
rm -fr .tmp_versions
make ARCH=arm CROSS_COMPILE=ccache arm-linux-gnueabihf- -C /home/build/workspace/OpenHD/OpenHDKernelBuilder/linux-pi M=/home/build/workspace/OpenHD/OpenHDKernelBuilder/rtl88x2bu  modules
make[1]: Entering directory '/home/build/workspace/OpenHD/OpenHDKernelBuilder/linux-pi'
./scripts/gcc-version.sh: line 26: ccachegcc: command not found
./scripts/gcc-version.sh: line 27: ccachegcc: command not found
make[1]: ccachegcc: Command not found
make[1]: *** No rule to make target 'arm-linux-gnueabihf-'.  Stop.
make[1]: Leaving directory '/home/build/workspace/OpenHD/OpenHDKernelBuilder/linux-pi'
make: *** [Makefile:2284: modules] Error 2
```
