### PR TITLE
2.2.4 evo v4l2

### DIFF
--- a/.github/workflows/buildPi.yml
+++ b/.github/workflows/buildPi.yml
@@ -16,7 +16,7 @@ jobs:
         PLATFORM: [pi]
         DISTRO: [bullseye]
     env:
-      CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
+     # CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/buildPi.yml
+++ b/.github/workflows/buildPi.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         PLATFORM: [pi]
         DISTRO: [bullseye]
-    env:
+    # env:
      # CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
 
     # Steps represent a sequence of tasks that will be executed as part of the job

--- a/.github/workflows/buildPiHeaders.yml
+++ b/.github/workflows/buildPiHeaders.yml
@@ -16,7 +16,7 @@ jobs:
         PLATFORM: [pi]
         DISTRO: [bullseye]
     env:
-      CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
+    #  CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/buildPiHeaders.yml
+++ b/.github/workflows/buildPiHeaders.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         PLATFORM: [pi]
         DISTRO: [bullseye]
-    env:
+    # env:
     #  CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
 
     # Steps represent a sequence of tasks that will be executed as part of the job

--- a/additional/Kconfig
+++ b/additional/Kconfig
@@ -55,41 +55,59 @@ config VIDEO_TDA7432
 	  To compile this driver as a module, choose M here: the
 	  module will be called tda7432.
 
-config VIDEO_VEYECAM
-        tristate "VEYECAM camera sensor support"
-	depends on I2C && VIDEO_V4L2 && VIDEO_V4L2_SUBDEV_API
-	help
-	  This driver supports VEYECAM camera sensor from veye.cc
-
-	  To compile this driver as a module, choose M here: the module
-	  will be called veyecam.
       
 config VIDEO_VEYEMVCAM
-        tristate "veye mv series camera sensor support"
-	depends on I2C && VIDEO_V4L2 && VIDEO_V4L2_SUBDEV_API
+	tristate "VEYE MV MIPI camera support"
+	depends on I2C && VIDEO_V4L2
+	select MEDIA_CONTROLLER
+	select VIDEO_V4L2_SUBDEV_API
+	select V4L2_FWNODE
 	help
-	  This driver supports veye mv series  camera sensor from veye.cc
+	  This is a Video4Linux2 sensor driver for the VEYE
+	  MV series cameras.
 
-	  To compile this driver as a module, choose M here: the module
-	  will be called veye_mvcam.
-
-config VIDEO_CSIMX307
-        tristate "CSIMX307 camera sensor support"
-	depends on I2C && VIDEO_V4L2 && VIDEO_V4L2_SUBDEV_API
-	help
-	  This driver supports CSIMX307 camera sensor from veye.cc
-
-	  To compile this driver as a module, choose M here: the module
-	  will be called csimx307.
+	  To compile this driver as a module, choose M here: the
+	  module will be called veyemvcam.
       
-config VIDEO_CSSC132
-        tristate "CSSC132 camera sensor support"
-	depends on I2C && VIDEO_V4L2 && VIDEO_V4L2_SUBDEV_API
+config VIDEO_VEYECAM2M
+	tristate "VEYE MIPI CAMERA 2M sensor support"
+	depends on I2C && VIDEO_V4L2
+	select MEDIA_CONTROLLER
+	select VIDEO_V4L2_SUBDEV_API
+	select V4L2_FWNODE
 	help
-	  This driver supports CSSC132 camera sensor from veye.cc
+	  This is a Video4Linux2 sensor driver for the VEYE
+	  IMX327 IMX462 IMX385.
 
-	  To compile this driver as a module, choose M here: the module
-	  will be called cssc132.
+	  To compile this driver as a module, choose M here: the
+	  module will be called veyecam2m.
+      
+config VIDEO_CSIMX307
+	tristate "VEYE CSIMX307 sensor support"
+	depends on I2C && VIDEO_V4L2
+	select MEDIA_CONTROLLER
+	select VIDEO_V4L2_SUBDEV_API
+	select V4L2_FWNODE
+	help
+	  This is a Video4Linux2 sensor driver for the VEYE
+	  CSIMX307 camera.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called csimx307.
+
+config VIDEO_CSSC132
+	tristate "VEYE CSSC132 sensor support"
+	depends on I2C && VIDEO_V4L2
+	select MEDIA_CONTROLLER
+	select VIDEO_V4L2_SUBDEV_API
+	select V4L2_FWNODE
+	help
+	  This is a Video4Linux2 sensor driver for the VEYE
+	  CSSC132 camera.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called cssc132.
+      
 
 config VIDEO_TDA9840
 	tristate "Philips TDA9840 audio processor"

--- a/additional/Kconfig
+++ b/additional/Kconfig
@@ -1,0 +1,1623 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Multimedia Video device configuration
+#
+
+if VIDEO_V4L2
+
+comment "IR I2C driver auto-selected by 'Autoselect ancillary drivers'"
+	depends on MEDIA_SUBDRV_AUTOSELECT && I2C && RC_CORE
+
+config VIDEO_IR_I2C
+	tristate "I2C module for IR" if !MEDIA_SUBDRV_AUTOSELECT || EXPERT
+	depends on I2C && RC_CORE
+	default y
+	help
+	  Most boards have an IR chip directly connected via GPIO. However,
+	  some video boards have the IR connected via I2C bus.
+
+	  If your board doesn't have an I2C IR chip, you may disable this
+	  option.
+
+	  In doubt, say Y.
+
+#
+# V4L2 I2C drivers that aren't related with Camera support
+#
+
+comment "audio, video and radio I2C drivers auto-selected by 'Autoselect ancillary drivers'"
+	depends on MEDIA_HIDE_ANCILLARY_SUBDRV
+#
+# Encoder / Decoder module configuration
+#
+
+menu "Audio decoders, processors and mixers"
+	visible if !MEDIA_HIDE_ANCILLARY_SUBDRV
+
+config VIDEO_TVAUDIO
+	tristate "Simple audio decoder chips"
+	depends on VIDEO_V4L2 && I2C
+	help
+	  Support for several audio decoder chips found on some bt8xx boards:
+	  Philips: tda9840, tda9873h, tda9874h/a, tda9850, tda985x, tea6300,
+		   tea6320, tea6420, tda8425, ta8874z.
+	  Microchip: pic16c54 based design on ProVideo PV951 board.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called tvaudio.
+
+config VIDEO_TDA7432
+	tristate "Philips TDA7432 audio processor"
+	depends on VIDEO_V4L2 && I2C
+	help
+	  Support for tda7432 audio decoder chip found on some bt8xx boards.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called tda7432.
+
+config VIDEO_VEYECAM
+        tristate "VEYECAM camera sensor support"
+	depends on I2C && VIDEO_V4L2 && VIDEO_V4L2_SUBDEV_API
+	help
+	  This driver supports VEYECAM camera sensor from veye.cc
+
+	  To compile this driver as a module, choose M here: the module
+	  will be called veyecam.
+      
+config VIDEO_VEYEMVCAM
+        tristate "veye mv series camera sensor support"
+	depends on I2C && VIDEO_V4L2 && VIDEO_V4L2_SUBDEV_API
+	help
+	  This driver supports veye mv series  camera sensor from veye.cc
+
+	  To compile this driver as a module, choose M here: the module
+	  will be called veye_mvcam.
+
+config VIDEO_CSIMX307
+        tristate "CSIMX307 camera sensor support"
+	depends on I2C && VIDEO_V4L2 && VIDEO_V4L2_SUBDEV_API
+	help
+	  This driver supports CSIMX307 camera sensor from veye.cc
+
+	  To compile this driver as a module, choose M here: the module
+	  will be called csimx307.
+      
+config VIDEO_CSSC132
+        tristate "CSSC132 camera sensor support"
+	depends on I2C && VIDEO_V4L2 && VIDEO_V4L2_SUBDEV_API
+	help
+	  This driver supports CSSC132 camera sensor from veye.cc
+
+	  To compile this driver as a module, choose M here: the module
+	  will be called cssc132.
+
+config VIDEO_TDA9840
+	tristate "Philips TDA9840 audio processor"
+	depends on I2C
+	help
+	  Support for tda9840 audio decoder chip found on some Zoran boards.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called tda9840.
+
+config VIDEO_TDA1997X
+	tristate "NXP TDA1997x HDMI receiver"
+	depends on VIDEO_V4L2 && I2C
+	depends on SND_SOC
+	select HDMI
+	select SND_PCM
+	select V4L2_FWNODE
+	select MEDIA_CONTROLLER
+	select VIDEO_V4L2_SUBDEV_API
+	help
+	  V4L2 subdevice driver for the NXP TDA1997x HDMI receivers.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called tda1997x.
+
+config VIDEO_TEA6415C
+	tristate "Philips TEA6415C audio processor"
+	depends on I2C
+	help
+	  Support for tea6415c audio decoder chip found on some bt8xx boards.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called tea6415c.
+
+config VIDEO_TEA6420
+	tristate "Philips TEA6420 audio processor"
+	depends on I2C
+	help
+	  Support for tea6420 audio decoder chip found on some bt8xx boards.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called tea6420.
+
+config VIDEO_MSP3400
+	tristate "Micronas MSP34xx audio decoders"
+	depends on VIDEO_V4L2 && I2C
+	help
+	  Support for the Micronas MSP34xx series of audio decoders.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called msp3400.
+
+config VIDEO_CS3308
+	tristate "Cirrus Logic CS3308 audio ADC"
+	depends on VIDEO_V4L2 && I2C
+	help
+	  Support for the Cirrus Logic CS3308 High Performance 8-Channel
+	  Analog Volume Control
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called cs3308.
+
+config VIDEO_CS5345
+	tristate "Cirrus Logic CS5345 audio ADC"
+	depends on VIDEO_V4L2 && I2C
+	help
+	  Support for the Cirrus Logic CS5345 24-bit, 192 kHz
+	  stereo A/D converter.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called cs5345.
+
+config VIDEO_CS53L32A
+	tristate "Cirrus Logic CS53L32A audio ADC"
+	depends on VIDEO_V4L2 && I2C
+	help
+	  Support for the Cirrus Logic CS53L32A low voltage
+	  stereo A/D converter.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called cs53l32a.
+
+config VIDEO_TLV320AIC23B
+	tristate "Texas Instruments TLV320AIC23B audio codec"
+	depends on VIDEO_V4L2 && I2C
+	help
+	  Support for the Texas Instruments TLV320AIC23B audio codec.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called tlv320aic23b.
+
+config VIDEO_UDA1342
+	tristate "Philips UDA1342 audio codec"
+	depends on VIDEO_V4L2 && I2C
+	help
+	  Support for the Philips UDA1342 audio codec.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called uda1342.
+
+config VIDEO_WM8775
+	tristate "Wolfson Microelectronics WM8775 audio ADC with input mixer"
+	depends on VIDEO_V4L2 && I2C
+	help
+	  Support for the Wolfson Microelectronics WM8775 high
+	  performance stereo A/D Converter with a 4 channel input mixer.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called wm8775.
+
+config VIDEO_WM8739
+	tristate "Wolfson Microelectronics WM8739 stereo audio ADC"
+	depends on VIDEO_V4L2 && I2C
+	help
+	  Support for the Wolfson Microelectronics WM8739
+	  stereo A/D Converter.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called wm8739.
+
+config VIDEO_VP27SMPX
+	tristate "Panasonic VP27's internal MPX"
+	depends on VIDEO_V4L2 && I2C
+	help
+	  Support for the internal MPX of the Panasonic VP27s tuner.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called vp27smpx.
+
+config VIDEO_SONY_BTF_MPX
+	tristate "Sony BTF's internal MPX"
+	depends on VIDEO_V4L2 && I2C
+	help
+	  Support for the internal MPX of the Sony BTF-PG472Z tuner.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called sony-btf-mpx.
+endmenu
+
+menu "RDS decoders"
+	visible if !MEDIA_HIDE_ANCILLARY_SUBDRV
+
+config VIDEO_SAA6588
+	tristate "SAA6588 Radio Chip RDS decoder support"
+	depends on VIDEO_V4L2 && I2C
+
+	help
+	  Support for this Radio Data System (RDS) decoder. This allows
+	  seeing radio station identification transmitted using this
+	  standard.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called saa6588.
+endmenu
+
+menu "Video decoders"
+	visible if !MEDIA_HIDE_ANCILLARY_SUBDRV
+
+config VIDEO_ADV7180
+	tristate "Analog Devices ADV7180 decoder"
+	depends on GPIOLIB && VIDEO_V4L2 && I2C
+	select MEDIA_CONTROLLER
+	select VIDEO_V4L2_SUBDEV_API
+	select V4L2_ASYNC
+	help
+	  Support for the Analog Devices ADV7180 video decoder.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called adv7180.
+
+config VIDEO_ADV7183
+	tristate "Analog Devices ADV7183 decoder"
+	depends on VIDEO_V4L2 && I2C
+	help
+	  V4l2 subdevice driver for the Analog Devices
+	  ADV7183 video decoder.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called adv7183.
+
+config VIDEO_ADV748X
+	tristate "Analog Devices ADV748x decoder"
+	depends on VIDEO_V4L2 && I2C
+	depends on OF
+	select MEDIA_CONTROLLER
+	select VIDEO_V4L2_SUBDEV_API
+	select REGMAP_I2C
+	select V4L2_FWNODE
+	help
+	  V4L2 subdevice driver for the Analog Devices
+	  ADV7481 and ADV7482 HDMI/Analog video decoders.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called adv748x.
+
+config VIDEO_ADV7604
+	tristate "Analog Devices ADV7604 decoder"
+	depends on VIDEO_V4L2 && I2C
+	depends on GPIOLIB || COMPILE_TEST
+	select MEDIA_CONTROLLER
+	select VIDEO_V4L2_SUBDEV_API
+	select REGMAP_I2C
+	select HDMI
+	select V4L2_FWNODE
+	help
+	  Support for the Analog Devices ADV7604 video decoder.
+
+	  This is a Analog Devices Component/Graphics Digitizer
+	  with 4:1 Multiplexed HDMI Receiver.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called adv7604.
+
+config VIDEO_ADV7604_CEC
+	bool "Enable Analog Devices ADV7604 CEC support"
+	depends on VIDEO_ADV7604
+	select CEC_CORE
+	help
+	  When selected the adv7604 will support the optional
+	  HDMI CEC feature.
+
+config VIDEO_ADV7842
+	tristate "Analog Devices ADV7842 decoder"
+	depends on VIDEO_V4L2 && I2C
+	select MEDIA_CONTROLLER
+	select VIDEO_V4L2_SUBDEV_API
+	select HDMI
+	help
+	  Support for the Analog Devices ADV7842 video decoder.
+
+	  This is a Analog Devices Component/Graphics/SD Digitizer
+	  with 2:1 Multiplexed HDMI Receiver.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called adv7842.
+
+config VIDEO_ADV7842_CEC
+	bool "Enable Analog Devices ADV7842 CEC support"
+	depends on VIDEO_ADV7842
+	select CEC_CORE
+	help
+	  When selected the adv7842 will support the optional
+	  HDMI CEC feature.
+
+config VIDEO_BT819
+	tristate "BT819A VideoStream decoder"
+	depends on VIDEO_V4L2 && I2C
+	help
+	  Support for BT819A video decoder.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called bt819.
+
+config VIDEO_BT856
+	tristate "BT856 VideoStream decoder"
+	depends on VIDEO_V4L2 && I2C
+	help
+	  Support for BT856 video decoder.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called bt856.
+
+config VIDEO_BT866
+	tristate "BT866 VideoStream decoder"
+	depends on VIDEO_V4L2 && I2C
+	help
+	  Support for BT866 video decoder.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called bt866.
+
+config VIDEO_KS0127
+	tristate "KS0127 video decoder"
+	depends on VIDEO_V4L2 && I2C
+	help
+	  Support for KS0127 video decoder.
+
+	  This chip is used on AverMedia AVS6EYES Zoran-based MJPEG
+	  cards.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called ks0127.
+
+config VIDEO_ML86V7667
+	tristate "OKI ML86V7667 video decoder"
+	depends on VIDEO_V4L2 && I2C
+	help
+	  Support for the OKI Semiconductor ML86V7667 video decoder.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called ml86v7667.
+
+config VIDEO_SAA7110
+	tristate "Philips SAA7110 video decoder"
+	depends on VIDEO_V4L2 && I2C
+	help
+	  Support for the Philips SAA7110 video decoders.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called saa7110.
+
+config VIDEO_SAA711X
+	tristate "Philips SAA7111/3/4/5 video decoders"
+	depends on VIDEO_V4L2 && I2C
+	help
+	  Support for the Philips SAA7111/3/4/5 video decoders.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called saa7115.
+
+config VIDEO_TC358743
+	tristate "Toshiba TC358743 decoder"
+	depends on VIDEO_V4L2 && I2C
+	select MEDIA_CONTROLLER
+	select VIDEO_V4L2_SUBDEV_API
+	select HDMI
+	select V4L2_FWNODE
+	help
+	  Support for the Toshiba TC358743 HDMI to MIPI CSI-2 bridge.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called tc358743.
+
+config VIDEO_TC358743_CEC
+	bool "Enable Toshiba TC358743 CEC support"
+	depends on VIDEO_TC358743
+	select CEC_CORE
+	help
+	  When selected the tc358743 will support the optional
+	  HDMI CEC feature.
+
+config VIDEO_TVP514X
+	tristate "Texas Instruments TVP514x video decoder"
+	depends on VIDEO_V4L2 && I2C
+	select V4L2_FWNODE
+	help
+	  This is a Video4Linux2 sensor driver for the TI TVP5146/47
+	  decoder. It is currently working with the TI OMAP3 camera
+	  controller.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called tvp514x.
+
+config VIDEO_TVP5150
+	tristate "Texas Instruments TVP5150 video decoder"
+	depends on VIDEO_V4L2 && I2C
+	select V4L2_FWNODE
+	select REGMAP_I2C
+	help
+	  Support for the Texas Instruments TVP5150 video decoder.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called tvp5150.
+
+config VIDEO_TVP7002
+	tristate "Texas Instruments TVP7002 video decoder"
+	depends on VIDEO_V4L2 && I2C
+	select V4L2_FWNODE
+	help
+	  Support for the Texas Instruments TVP7002 video decoder.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called tvp7002.
+
+config VIDEO_TW2804
+	tristate "Techwell TW2804 multiple video decoder"
+	depends on VIDEO_V4L2 && I2C
+	help
+	  Support for the Techwell tw2804 multiple video decoder.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called tw2804.
+
+config VIDEO_TW9903
+	tristate "Techwell TW9903 video decoder"
+	depends on VIDEO_V4L2 && I2C
+	help
+	  Support for the Techwell tw9903 multi-standard video decoder
+	  with high quality down scaler.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called tw9903.
+
+config VIDEO_TW9906
+	tristate "Techwell TW9906 video decoder"
+	depends on VIDEO_V4L2 && I2C
+	help
+	  Support for the Techwell tw9906 enhanced multi-standard comb filter
+	  video decoder with YCbCr input support.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called tw9906.
+
+config VIDEO_TW9910
+	tristate "Techwell TW9910 video decoder"
+	depends on VIDEO_V4L2 && I2C
+	help
+	  Support for Techwell TW9910 NTSC/PAL/SECAM video decoder.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called tw9910.
+
+config VIDEO_VPX3220
+	tristate "vpx3220a, vpx3216b & vpx3214c video decoders"
+	depends on VIDEO_V4L2 && I2C
+	help
+	  Support for VPX322x video decoders.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called vpx3220.
+
+config VIDEO_MAX9286
+	tristate "Maxim MAX9286 GMSL deserializer support"
+	depends on I2C && I2C_MUX
+	depends on OF_GPIO
+	select V4L2_FWNODE
+	select VIDEO_V4L2_SUBDEV_API
+	select MEDIA_CONTROLLER
+	help
+	  This driver supports the Maxim MAX9286 GMSL deserializer.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called max9286.
+
+comment "Video and audio decoders"
+
+config VIDEO_SAA717X
+	tristate "Philips SAA7171/3/4 audio/video decoders"
+	depends on VIDEO_V4L2 && I2C
+	help
+	  Support for the Philips SAA7171/3/4 audio/video decoders.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called saa717x.
+
+source "drivers/media/i2c/cx25840/Kconfig"
+
+endmenu
+
+menu "Video encoders"
+	visible if !MEDIA_HIDE_ANCILLARY_SUBDRV
+
+config VIDEO_SAA7127
+	tristate "Philips SAA7127/9 digital video encoders"
+	depends on VIDEO_V4L2 && I2C
+	help
+	  Support for the Philips SAA7127/9 digital video encoders.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called saa7127.
+
+config VIDEO_SAA7185
+	tristate "Philips SAA7185 video encoder"
+	depends on VIDEO_V4L2 && I2C
+	help
+	  Support for the Philips SAA7185 video encoder.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called saa7185.
+
+config VIDEO_ADV7170
+	tristate "Analog Devices ADV7170 video encoder"
+	depends on VIDEO_V4L2 && I2C
+	help
+	  Support for the Analog Devices ADV7170 video encoder driver
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called adv7170.
+
+config VIDEO_ADV7175
+	tristate "Analog Devices ADV7175 video encoder"
+	depends on VIDEO_V4L2 && I2C
+	help
+	  Support for the Analog Devices ADV7175 video encoder driver
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called adv7175.
+
+config VIDEO_ADV7343
+	tristate "ADV7343 video encoder"
+	depends on I2C
+	select V4L2_ASYNC
+	help
+	  Support for Analog Devices I2C bus based ADV7343 encoder.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called adv7343.
+
+config VIDEO_ADV7393
+	tristate "ADV7393 video encoder"
+	depends on I2C
+	help
+	  Support for Analog Devices I2C bus based ADV7393 encoder.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called adv7393.
+
+config VIDEO_ADV7511
+	tristate "Analog Devices ADV7511 encoder"
+	depends on VIDEO_V4L2 && I2C
+	depends on DRM_I2C_ADV7511=n || COMPILE_TEST
+	select MEDIA_CONTROLLER
+	select VIDEO_V4L2_SUBDEV_API
+	select HDMI
+	help
+	  Support for the Analog Devices ADV7511 video encoder.
+
+	  This is a Analog Devices HDMI transmitter.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called adv7511.
+
+config VIDEO_ADV7511_CEC
+	bool "Enable Analog Devices ADV7511 CEC support"
+	depends on VIDEO_ADV7511
+	select CEC_CORE
+	help
+	  When selected the adv7511 will support the optional
+	  HDMI CEC feature.
+
+config VIDEO_AD9389B
+	tristate "Analog Devices AD9389B encoder"
+	depends on VIDEO_V4L2 && I2C
+	select MEDIA_CONTROLLER
+	select VIDEO_V4L2_SUBDEV_API
+
+	help
+	  Support for the Analog Devices AD9389B video encoder.
+
+	  This is a Analog Devices HDMI transmitter.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called ad9389b.
+
+config VIDEO_AK881X
+	tristate "AK8813/AK8814 video encoders"
+	depends on I2C
+	help
+	  Video output driver for AKM AK8813 and AK8814 TV encoders
+
+config VIDEO_THS8200
+	tristate "Texas Instruments THS8200 video encoder"
+	depends on VIDEO_V4L2 && I2C
+	select V4L2_ASYNC
+	help
+	  Support for the Texas Instruments THS8200 video encoder.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called ths8200.
+endmenu
+
+menu "Video improvement chips"
+	visible if !MEDIA_HIDE_ANCILLARY_SUBDRV
+
+config VIDEO_UPD64031A
+	tristate "NEC Electronics uPD64031A Ghost Reduction"
+	depends on VIDEO_V4L2 && I2C
+	help
+	  Support for the NEC Electronics uPD64031A Ghost Reduction
+	  video chip. It is most often found in NTSC TV cards made for
+	  Japan and is used to reduce the 'ghosting' effect that can
+	  be present in analog TV broadcasts.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called upd64031a.
+
+config VIDEO_UPD64083
+	tristate "NEC Electronics uPD64083 3-Dimensional Y/C separation"
+	depends on VIDEO_V4L2 && I2C
+	help
+	  Support for the NEC Electronics uPD64083 3-Dimensional Y/C
+	  separation video chip. It is used to improve the quality of
+	  the colors of a composite signal.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called upd64083.
+endmenu
+
+menu "Audio/Video compression chips"
+	visible if !MEDIA_HIDE_ANCILLARY_SUBDRV
+
+config VIDEO_SAA6752HS
+	tristate "Philips SAA6752HS MPEG-2 Audio/Video Encoder"
+	depends on VIDEO_V4L2 && I2C
+	select CRC32
+	help
+	  Support for the Philips SAA6752HS MPEG-2 video and MPEG-audio/AC-3
+	  audio encoder with multiplexer.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called saa6752hs.
+
+endmenu
+
+menu "SDR tuner chips"
+	visible if !MEDIA_HIDE_ANCILLARY_SUBDRV
+
+config SDR_MAX2175
+	tristate "Maxim 2175 RF to Bits tuner"
+	depends on VIDEO_V4L2 && MEDIA_SDR_SUPPORT && I2C
+	select REGMAP_I2C
+	select V4L2_ASYNC
+	help
+	  Support for Maxim 2175 tuner. It is an advanced analog/digital
+	  radio receiver with RF-to-Bits front-end designed for SDR solutions.
+
+	  To compile this driver as a module, choose M here; the
+	  module will be called max2175.
+
+
+endmenu
+
+menu "Miscellaneous helper chips"
+	visible if !MEDIA_HIDE_ANCILLARY_SUBDRV
+
+config VIDEO_THS7303
+	tristate "THS7303/53 Video Amplifier"
+	depends on VIDEO_V4L2 && I2C
+	select V4L2_ASYNC
+	help
+	  Support for TI THS7303/53 video amplifier
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called ths7303.
+
+config VIDEO_M52790
+	tristate "Mitsubishi M52790 A/V switch"
+	depends on VIDEO_V4L2 && I2C
+	help
+	 Support for the Mitsubishi M52790 A/V switch.
+
+	 To compile this driver as a module, choose M here: the
+	 module will be called m52790.
+
+config VIDEO_I2C
+	tristate "I2C transport video support"
+	depends on VIDEO_V4L2 && I2C
+	select VIDEOBUF2_VMALLOC
+	imply HWMON
+	help
+	  Enable the I2C transport video support which supports the
+	  following:
+	   * Panasonic AMG88xx Grid-Eye Sensors
+	   * Melexis MLX90640 Thermal Cameras
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called video-i2c
+
+config VIDEO_ST_MIPID02
+	tristate "STMicroelectronics MIPID02 CSI-2 to PARALLEL bridge"
+	depends on I2C && VIDEO_V4L2
+	select MEDIA_CONTROLLER
+	select VIDEO_V4L2_SUBDEV_API
+	select V4L2_FWNODE
+	help
+	  Support for STMicroelectronics MIPID02 CSI-2 to PARALLEL bridge.
+	  It is used to allow usage of CSI-2 sensor with PARALLEL port
+	  controller.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called st-mipid02.
+endmenu
+
+#
+# V4L2 I2C drivers that are related with Camera support
+#
+
+menu "Camera sensor devices"
+	visible if MEDIA_CAMERA_SUPPORT
+
+config VIDEO_APTINA_PLL
+	tristate
+
+config VIDEO_CCS_PLL
+	tristate
+
+config VIDEO_ARDUCAM_64MP
+	tristate "Arducam 64MP sensor support"
+	depends on I2C && VIDEO_V4L2 && VIDEO_V4L2_SUBDEV_API
+	depends on MEDIA_CAMERA_SUPPORT
+	help
+	  This is a Video4Linux2 sensor driver for the Arducam
+	  64MP camera.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called arducam_64mp.
+
+config VIDEO_ARDUCAM_PIVARIETY
+	tristate "Arducam Pivariety sensor support"
+	depends on I2C && VIDEO_V4L2 && VIDEO_V4L2_SUBDEV_API
+	depends on MEDIA_CAMERA_SUPPORT
+	help
+	  This is a Video4Linux2 sensor driver for the Arducam
+	  Pivariety camera series.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called arducam-pivariety.
+
+config VIDEO_HI556
+	tristate "Hynix Hi-556 sensor support"
+	depends on I2C && VIDEO_V4L2
+	select MEDIA_CONTROLLER
+	select VIDEO_V4L2_SUBDEV_API
+	select V4L2_FWNODE
+	help
+	  This is a Video4Linux2 sensor driver for the Hynix
+	  Hi-556 camera.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called hi556.
+
+config VIDEO_IMX208
+	tristate "Sony IMX208 sensor support"
+	depends on I2C && VIDEO_V4L2 && VIDEO_V4L2_SUBDEV_API
+	depends on MEDIA_CAMERA_SUPPORT
+	help
+	  This is a Video4Linux2 sensor driver for the Sony
+	  IMX208 camera.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called imx208.
+
+config VIDEO_IMX214
+	tristate "Sony IMX214 sensor support"
+	depends on GPIOLIB && I2C && VIDEO_V4L2
+	select V4L2_FWNODE
+	select MEDIA_CONTROLLER
+	select VIDEO_V4L2_SUBDEV_API
+	select REGMAP_I2C
+	help
+	  This is a Video4Linux2 sensor driver for the Sony
+	  IMX214 camera.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called imx214.
+
+config VIDEO_IMX219
+	tristate "Sony IMX219 sensor support"
+	depends on I2C && VIDEO_V4L2
+	select MEDIA_CONTROLLER
+	select VIDEO_V4L2_SUBDEV_API
+	select V4L2_FWNODE
+	help
+	  This is a Video4Linux2 sensor driver for the Sony
+	  IMX219 camera.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called imx219.
+
+config VIDEO_IMX258
+	tristate "Sony IMX258 sensor support"
+	depends on I2C && VIDEO_V4L2
+	select MEDIA_CONTROLLER
+	select VIDEO_V4L2_SUBDEV_API
+	help
+	  This is a Video4Linux2 sensor driver for the Sony
+	  IMX258 camera.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called imx258.
+
+config VIDEO_IMX274
+	tristate "Sony IMX274 sensor support"
+	depends on I2C && VIDEO_V4L2
+	select MEDIA_CONTROLLER
+	select VIDEO_V4L2_SUBDEV_API
+	select REGMAP_I2C
+	help
+	  This is a V4L2 sensor driver for the Sony IMX274
+	  CMOS image sensor.
+
+config VIDEO_IMX290
+	tristate "Sony IMX290 sensor support"
+	depends on I2C && VIDEO_V4L2
+	select MEDIA_CONTROLLER
+	select VIDEO_V4L2_SUBDEV_API
+	select REGMAP_I2C
+	select V4L2_FWNODE
+	help
+	  This is a Video4Linux2 sensor driver for the Sony
+	  IMX290 camera sensor.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called imx290.
+
+config VIDEO_IMX296
+	tristate "Sony IMX296 sensor support"
+	depends on I2C && VIDEO_V4L2 && VIDEO_V4L2_SUBDEV_API
+	depends on MEDIA_CAMERA_SUPPORT
+	select V4L2_FWNODE
+	help
+	  This is a Video4Linux2 sensor driver for the Sony
+	  IMX296 camera.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called imx296.
+
+config VIDEO_IMX477
+	tristate "Sony IMX477 sensor support"
+	depends on I2C && VIDEO_V4L2 && VIDEO_V4L2_SUBDEV_API
+	depends on MEDIA_CAMERA_SUPPORT
+	help
+	  This is a Video4Linux2 sensor driver for the Sony
+	  IMX477 camera. Also supports the Sony IMX378.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called imx477.
+
+config VIDEO_IMX319
+	tristate "Sony IMX319 sensor support"
+	depends on I2C && VIDEO_V4L2
+	select MEDIA_CONTROLLER
+	select VIDEO_V4L2_SUBDEV_API
+	help
+	  This is a Video4Linux2 sensor driver for the Sony
+	  IMX319 camera.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called imx319.
+
+config VIDEO_IMX334
+	tristate "Sony IMX334 sensor support"
+	depends on OF_GPIO
+	depends on I2C && VIDEO_V4L2
+	select VIDEO_V4L2_SUBDEV_API
+	select MEDIA_CONTROLLER
+	select V4L2_FWNODE
+	help
+	  This is a Video4Linux2 sensor driver for the Sony
+	  IMX334 camera.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called imx334.
+
+config VIDEO_IMX335
+	tristate "Sony IMX335 sensor support"
+	depends on OF_GPIO
+	depends on I2C && VIDEO_V4L2
+	select VIDEO_V4L2_SUBDEV_API
+	select MEDIA_CONTROLLER
+	select V4L2_FWNODE
+	help
+	  This is a Video4Linux2 sensor driver for the Sony
+	  IMX335 camera.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called imx335.
+
+config VIDEO_IMX355
+	tristate "Sony IMX355 sensor support"
+	depends on I2C && VIDEO_V4L2
+	select MEDIA_CONTROLLER
+	select VIDEO_V4L2_SUBDEV_API
+	help
+	  This is a Video4Linux2 sensor driver for the Sony
+	  IMX355 camera.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called imx355.
+
+config VIDEO_IMX412
+	tristate "Sony IMX412 sensor support"
+	depends on OF_GPIO
+	depends on I2C && VIDEO_V4L2
+	select VIDEO_V4L2_SUBDEV_API
+	select MEDIA_CONTROLLER
+	select V4L2_FWNODE
+	help
+	  This is a Video4Linux2 sensor driver for the Sony
+	  IMX412 camera.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called imx412.
+
+config VIDEO_IMX519
+	tristate "Arducam IMX519 sensor support"
+	depends on I2C && VIDEO_V4L2 && VIDEO_V4L2_SUBDEV_API
+	depends on MEDIA_CAMERA_SUPPORT
+	help
+	  This is a Video4Linux2 sensor driver for the Arducam
+	  IMX519 camera.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called IMX519.
+
+config VIDEO_OV02A10
+	tristate "OmniVision OV02A10 sensor support"
+	depends on VIDEO_V4L2 && I2C
+	select MEDIA_CONTROLLER
+	select VIDEO_V4L2_SUBDEV_API
+	select V4L2_FWNODE
+	help
+	  This is a Video4Linux2 sensor driver for the OmniVision
+	  OV02A10 camera.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called ov02a10.
+
+config VIDEO_OV2311
+	tristate "OmniVision OV2311 sensor support"
+	depends on I2C && VIDEO_V4L2
+	depends on MEDIA_CAMERA_SUPPORT
+	help
+	  This is a Video4Linux2 sensor-level driver for the OmniVision
+	  OV2311 camera.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called ov2311.
+
+config VIDEO_OV2640
+	tristate "OmniVision OV2640 sensor support"
+	depends on VIDEO_V4L2 && I2C
+	help
+	  This is a Video4Linux2 sensor driver for the OmniVision
+	  OV2640 camera.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called ov2640.
+
+config VIDEO_OV2659
+	tristate "OmniVision OV2659 sensor support"
+	depends on VIDEO_V4L2 && I2C && GPIOLIB
+	select V4L2_FWNODE
+	help
+	  This is a Video4Linux2 sensor driver for the OmniVision
+	  OV2659 camera.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called ov2659.
+
+config VIDEO_OV2680
+	tristate "OmniVision OV2680 sensor support"
+	depends on VIDEO_V4L2 && I2C
+	select MEDIA_CONTROLLER
+	select V4L2_FWNODE
+	help
+	  This is a Video4Linux2 sensor driver for the OmniVision
+	  OV2680 camera.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called ov2680.
+
+config VIDEO_OV2685
+	tristate "OmniVision OV2685 sensor support"
+	depends on VIDEO_V4L2 && I2C
+	select MEDIA_CONTROLLER
+	select V4L2_FWNODE
+	help
+	  This is a Video4Linux2 sensor driver for the OmniVision
+	  OV2685 camera.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called ov2685.
+
+config VIDEO_OV2740
+	tristate "OmniVision OV2740 sensor support"
+	depends on VIDEO_V4L2 && I2C
+	depends on ACPI || COMPILE_TEST
+	select MEDIA_CONTROLLER
+	select VIDEO_V4L2_SUBDEV_API
+	select V4L2_FWNODE
+	select REGMAP_I2C
+	help
+	  This is a Video4Linux2 sensor driver for the OmniVision
+	  OV2740 camera.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called ov2740.
+
+config VIDEO_OV5640
+	tristate "OmniVision OV5640 sensor support"
+	depends on OF
+	depends on GPIOLIB && VIDEO_V4L2 && I2C
+	select MEDIA_CONTROLLER
+	select VIDEO_V4L2_SUBDEV_API
+	select V4L2_FWNODE
+	help
+	  This is a Video4Linux2 sensor driver for the Omnivision
+	  OV5640 camera sensor with a MIPI CSI-2 interface.
+
+config VIDEO_OV5645
+	tristate "OmniVision OV5645 sensor support"
+	depends on OF
+	depends on I2C && VIDEO_V4L2
+	select MEDIA_CONTROLLER
+	select VIDEO_V4L2_SUBDEV_API
+	select V4L2_FWNODE
+	help
+	  This is a Video4Linux2 sensor driver for the OmniVision
+	  OV5645 camera.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called ov5645.
+
+config VIDEO_OV5647
+	tristate "OmniVision OV5647 sensor support"
+	depends on I2C && VIDEO_V4L2
+	select MEDIA_CONTROLLER
+	select VIDEO_V4L2_SUBDEV_API
+	select V4L2_FWNODE
+	help
+	  This is a Video4Linux2 sensor driver for the OmniVision
+	  OV5647 camera.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called ov5647.
+
+config VIDEO_OV5648
+	tristate "OmniVision OV5648 sensor support"
+	depends on I2C && PM && VIDEO_V4L2
+	select MEDIA_CONTROLLER
+	select VIDEO_V4L2_SUBDEV_API
+	select V4L2_FWNODE
+	help
+	  This is a Video4Linux2 sensor driver for the OmniVision
+	  OV5648 camera.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called ov5648.
+
+config VIDEO_OV6650
+	tristate "OmniVision OV6650 sensor support"
+	depends on I2C && VIDEO_V4L2
+	help
+	  This is a Video4Linux2 sensor driver for the OmniVision
+	  OV6650 camera.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called ov6650.
+
+config VIDEO_OV5670
+	tristate "OmniVision OV5670 sensor support"
+	depends on I2C && VIDEO_V4L2
+	select MEDIA_CONTROLLER
+	select VIDEO_V4L2_SUBDEV_API
+	select V4L2_FWNODE
+	help
+	  This is a Video4Linux2 sensor driver for the OmniVision
+	  OV5670 camera.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called ov5670.
+
+config VIDEO_OV5675
+	tristate "OmniVision OV5675 sensor support"
+	depends on I2C && VIDEO_V4L2
+	select MEDIA_CONTROLLER
+	select VIDEO_V4L2_SUBDEV_API
+	select V4L2_FWNODE
+	help
+	  This is a Video4Linux2 sensor driver for the OmniVision
+	  OV5675 camera.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called ov5675.
+
+config VIDEO_OV5695
+	tristate "OmniVision OV5695 sensor support"
+	depends on I2C && VIDEO_V4L2
+	select V4L2_FWNODE
+	help
+	  This is a Video4Linux2 sensor driver for the OmniVision
+	  OV5695 camera.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called ov5695.
+
+config VIDEO_OV7251
+	tristate "OmniVision OV7251 sensor support"
+	depends on I2C && VIDEO_V4L2
+	select MEDIA_CONTROLLER
+	select VIDEO_V4L2_SUBDEV_API
+	select V4L2_FWNODE
+	help
+	  This is a Video4Linux2 sensor driver for the OmniVision
+	  OV7251 camera.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called ov7251.
+
+config VIDEO_OV772X
+	tristate "OmniVision OV772x sensor support"
+	depends on I2C && VIDEO_V4L2
+	select REGMAP_SCCB
+	select V4L2_FWNODE
+	help
+	  This is a Video4Linux2 sensor driver for the OmniVision
+	  OV772x camera.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called ov772x.
+
+config VIDEO_OV7640
+	tristate "OmniVision OV7640 sensor support"
+	depends on I2C && VIDEO_V4L2
+	help
+	  This is a Video4Linux2 sensor driver for the OmniVision
+	  OV7640 camera.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called ov7640.
+
+config VIDEO_OV7670
+	tristate "OmniVision OV7670 sensor support"
+	depends on I2C && VIDEO_V4L2
+	select V4L2_FWNODE
+	help
+	  This is a Video4Linux2 sensor driver for the OmniVision
+	  OV7670 VGA camera.  It currently only works with the M88ALP01
+	  controller.
+
+config VIDEO_OV7740
+	tristate "OmniVision OV7740 sensor support"
+	depends on I2C && VIDEO_V4L2
+	select REGMAP_SCCB
+	help
+	  This is a Video4Linux2 sensor driver for the OmniVision
+	  OV7740 VGA camera sensor.
+
+config VIDEO_OV8856
+	tristate "OmniVision OV8856 sensor support"
+	depends on I2C && VIDEO_V4L2
+	select MEDIA_CONTROLLER
+	select VIDEO_V4L2_SUBDEV_API
+	select V4L2_FWNODE
+	help
+	  This is a Video4Linux2 sensor driver for the OmniVision
+	  OV8856 camera sensor.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called ov8856.
+
+config VIDEO_OV8865
+	tristate "OmniVision OV8865 sensor support"
+	depends on I2C && PM && VIDEO_V4L2
+	select MEDIA_CONTROLLER
+	select VIDEO_V4L2_SUBDEV_API
+	select V4L2_FWNODE
+	help
+	  This is a Video4Linux2 sensor driver for OmniVision
+	  OV8865 camera sensor.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called ov8865.
+
+config VIDEO_OV9282
+	tristate "OmniVision OV9282 sensor support"
+	depends on OF_GPIO
+	depends on I2C && VIDEO_V4L2
+	select VIDEO_V4L2_SUBDEV_API
+	select MEDIA_CONTROLLER
+	select V4L2_FWNODE
+	help
+	  This is a Video4Linux2 sensor driver for the OmniVision
+	  OV9282 camera sensor.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called ov9282.
+
+config VIDEO_OV9640
+	tristate "OmniVision OV9640 sensor support"
+	depends on I2C && VIDEO_V4L2
+	help
+	  This is a Video4Linux2 sensor driver for the OmniVision
+	  OV9640 camera sensor.
+
+config VIDEO_OV9281
+	tristate "OmniVision OV9281 sensor support"
+	depends on I2C && VIDEO_V4L2
+	depends on MEDIA_CAMERA_SUPPORT
+	help
+	  This is a Video4Linux2 sensor-level driver for the OmniVision
+	  OV9281 camera.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called ov9281.
+
+config VIDEO_OV9650
+	tristate "OmniVision OV9650/OV9652 sensor support"
+	depends on I2C && VIDEO_V4L2
+	select MEDIA_CONTROLLER
+	select VIDEO_V4L2_SUBDEV_API
+	select REGMAP_SCCB
+	help
+	  This is a V4L2 sensor driver for the Omnivision
+	  OV9650 and OV9652 camera sensors.
+
+config VIDEO_OV9734
+	tristate "OmniVision OV9734 sensor support"
+	depends on VIDEO_V4L2 && I2C
+	depends on ACPI || COMPILE_TEST
+	select MEDIA_CONTROLLER
+	select VIDEO_V4L2_SUBDEV_API
+	select V4L2_FWNODE
+	help
+	  This is a Video4Linux2 sensor driver for the OmniVision
+	  OV9734 camera.
+
+	  To compile this driver as a module, choose M here: the
+	  module's name is ov9734.
+
+config VIDEO_OV13858
+	tristate "OmniVision OV13858 sensor support"
+	depends on I2C && VIDEO_V4L2
+	select MEDIA_CONTROLLER
+	select VIDEO_V4L2_SUBDEV_API
+	select V4L2_FWNODE
+	help
+	  This is a Video4Linux2 sensor driver for the OmniVision
+	  OV13858 camera.
+
+config VIDEO_IRS1125
+	tristate "Infineon IRS1125 sensor support"
+	depends on I2C && VIDEO_V4L2 && VIDEO_V4L2_SUBDEV_API
+	depends on MEDIA_CAMERA_SUPPORT
+	select V4L2_FWNODE
+	help
+	  This is a Video4Linux2 sensor-level driver for the Infineon
+	  IRS1125 camera.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called irs1125.
+
+config VIDEO_VS6624
+	tristate "ST VS6624 sensor support"
+	depends on VIDEO_V4L2 && I2C
+	help
+	  This is a Video4Linux2 sensor driver for the ST VS6624
+	  camera.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called vs6624.
+
+config VIDEO_MT9M001
+	tristate "mt9m001 support"
+	depends on I2C && VIDEO_V4L2
+	select MEDIA_CONTROLLER
+	select VIDEO_V4L2_SUBDEV_API
+	help
+	  This driver supports MT9M001 cameras from Micron, monochrome
+	  and colour models.
+
+config VIDEO_MT9M032
+	tristate "MT9M032 camera sensor support"
+	depends on I2C && VIDEO_V4L2
+	select MEDIA_CONTROLLER
+	select VIDEO_V4L2_SUBDEV_API
+	select VIDEO_APTINA_PLL
+	help
+	  This driver supports MT9M032 camera sensors from Aptina, monochrome
+	  models only.
+
+config VIDEO_MT9M111
+	tristate "mt9m111, mt9m112 and mt9m131 support"
+	depends on I2C && VIDEO_V4L2
+	select V4L2_FWNODE
+	help
+	  This driver supports MT9M111, MT9M112 and MT9M131 cameras from
+	  Micron/Aptina
+
+config VIDEO_MT9P031
+	tristate "Aptina MT9P031 support"
+	depends on I2C && VIDEO_V4L2
+	select MEDIA_CONTROLLER
+	select VIDEO_V4L2_SUBDEV_API
+	select VIDEO_APTINA_PLL
+	help
+	  This is a Video4Linux2 sensor driver for the Aptina
+	  (Micron) mt9p031 5 Mpixel camera.
+
+config VIDEO_MT9T001
+	tristate "Aptina MT9T001 support"
+	depends on I2C && VIDEO_V4L2
+	select MEDIA_CONTROLLER
+	select VIDEO_V4L2_SUBDEV_API
+	help
+	  This is a Video4Linux2 sensor driver for the Aptina
+	  (Micron) mt0t001 3 Mpixel camera.
+
+config VIDEO_MT9T112
+	tristate "Aptina MT9T111/MT9T112 support"
+	depends on I2C && VIDEO_V4L2
+	help
+	  This is a Video4Linux2 sensor driver for the Aptina
+	  (Micron) MT9T111 and MT9T112 3 Mpixel camera.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called mt9t112.
+
+config VIDEO_MT9V011
+	tristate "Micron mt9v011 sensor support"
+	depends on I2C && VIDEO_V4L2
+	help
+	  This is a Video4Linux2 sensor driver for the Micron
+	  mt0v011 1.3 Mpixel camera.  It currently only works with the
+	  em28xx driver.
+
+config VIDEO_MT9V032
+	tristate "Micron MT9V032 sensor support"
+	depends on I2C && VIDEO_V4L2
+	select MEDIA_CONTROLLER
+	select VIDEO_V4L2_SUBDEV_API
+	select REGMAP_I2C
+	select V4L2_FWNODE
+	help
+	  This is a Video4Linux2 sensor driver for the Micron
+	  MT9V032 752x480 CMOS sensor.
+
+config VIDEO_MT9V111
+	tristate "Aptina MT9V111 sensor support"
+	depends on I2C && VIDEO_V4L2
+	help
+	  This is a Video4Linux2 sensor driver for the Aptina/Micron
+	  MT9V111 sensor.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called mt9v111.
+
+config VIDEO_SR030PC30
+	tristate "Siliconfile SR030PC30 sensor support"
+	depends on I2C && VIDEO_V4L2
+	help
+	  This driver supports SR030PC30 VGA camera from Siliconfile
+
+config VIDEO_NOON010PC30
+	tristate "Siliconfile NOON010PC30 sensor support"
+	depends on I2C && VIDEO_V4L2
+	select MEDIA_CONTROLLER
+	select VIDEO_V4L2_SUBDEV_API
+	help
+	  This driver supports NOON010PC30 CIF camera from Siliconfile
+
+source "drivers/media/i2c/m5mols/Kconfig"
+
+config VIDEO_MAX9271_LIB
+	tristate
+
+config VIDEO_RDACM20
+	tristate "IMI RDACM20 camera support"
+	depends on I2C
+	select V4L2_FWNODE
+	select VIDEO_V4L2_SUBDEV_API
+	select MEDIA_CONTROLLER
+	select VIDEO_MAX9271_LIB
+	help
+	  This driver supports the IMI RDACM20 GMSL camera, used in
+	  ADAS systems.
+
+	  This camera should be used in conjunction with a GMSL
+	  deserialiser such as the MAX9286.
+
+config VIDEO_RDACM21
+	tristate "IMI RDACM21 camera support"
+	depends on I2C
+	select V4L2_FWNODE
+	select VIDEO_V4L2_SUBDEV_API
+	select MEDIA_CONTROLLER
+	select VIDEO_MAX9271_LIB
+	help
+	  This driver supports the IMI RDACM21 GMSL camera, used in
+	  ADAS systems.
+
+	  This camera should be used in conjunction with a GMSL
+	  deserialiser such as the MAX9286.
+
+config VIDEO_RJ54N1
+	tristate "Sharp RJ54N1CB0C sensor support"
+	depends on I2C && VIDEO_V4L2
+	help
+	  This is a V4L2 sensor driver for Sharp RJ54N1CB0C CMOS image
+	  sensor.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called rj54n1.
+
+config VIDEO_S5K6AA
+	tristate "Samsung S5K6AAFX sensor support"
+	depends on I2C && VIDEO_V4L2
+	select MEDIA_CONTROLLER
+	select VIDEO_V4L2_SUBDEV_API
+	help
+	  This is a V4L2 sensor driver for Samsung S5K6AA(FX) 1.3M
+	  camera sensor with an embedded SoC image signal processor.
+
+config VIDEO_S5K6A3
+	tristate "Samsung S5K6A3 sensor support"
+	depends on I2C && VIDEO_V4L2
+	select MEDIA_CONTROLLER
+	select VIDEO_V4L2_SUBDEV_API
+	help
+	  This is a V4L2 sensor driver for Samsung S5K6A3 raw
+	  camera sensor.
+
+config VIDEO_S5K4ECGX
+	tristate "Samsung S5K4ECGX sensor support"
+	depends on I2C && VIDEO_V4L2
+	select MEDIA_CONTROLLER
+	select VIDEO_V4L2_SUBDEV_API
+	select CRC32
+	help
+	  This is a V4L2 sensor driver for Samsung S5K4ECGX 5M
+	  camera sensor with an embedded SoC image signal processor.
+
+config VIDEO_S5K5BAF
+	tristate "Samsung S5K5BAF sensor support"
+	depends on I2C && VIDEO_V4L2
+	select MEDIA_CONTROLLER
+	select VIDEO_V4L2_SUBDEV_API
+	select V4L2_FWNODE
+	help
+	  This is a V4L2 sensor driver for Samsung S5K5BAF 2M
+	  camera sensor with an embedded SoC image signal processor.
+
+source "drivers/media/i2c/ccs/Kconfig"
+source "drivers/media/i2c/et8ek8/Kconfig"
+
+config VIDEO_S5C73M3
+	tristate "Samsung S5C73M3 sensor support"
+	depends on I2C && SPI && VIDEO_V4L2
+	select MEDIA_CONTROLLER
+	select VIDEO_V4L2_SUBDEV_API
+	select V4L2_FWNODE
+	help
+	  This is a V4L2 sensor driver for Samsung S5C73M3
+	  8 Mpixel camera.
+
+endmenu
+
+menu "Lens drivers"
+	visible if MEDIA_CAMERA_SUPPORT
+
+config VIDEO_AD5398
+	tristate "AD5398 lens voice coil support"
+	depends on GPIOLIB && I2C && VIDEO_V4L2
+	select MEDIA_CONTROLLER
+	help
+	  This is a driver for the AD5398 camera lens voice coil.
+
+config VIDEO_AD5820
+	tristate "AD5820 lens voice coil support"
+	depends on GPIOLIB && I2C && VIDEO_V4L2
+	select MEDIA_CONTROLLER
+	select V4L2_ASYNC
+	help
+	  This is a driver for the AD5820 camera lens voice coil.
+	  It is used for example in Nokia N900 (RX-51).
+
+config VIDEO_AK7375
+	tristate "AK7375 lens voice coil support"
+	depends on I2C && VIDEO_V4L2
+	select MEDIA_CONTROLLER
+	select VIDEO_V4L2_SUBDEV_API
+	select V4L2_ASYNC
+	help
+	  This is a driver for the AK7375 camera lens voice coil.
+	  AK7375 is a 12 bit DAC with 120mA output current sink
+	  capability. This is designed for linear control of
+	  voice coil motors, controlled via I2C serial interface.
+
+config VIDEO_DW9714
+	tristate "DW9714 lens voice coil support"
+	depends on I2C && VIDEO_V4L2
+	select MEDIA_CONTROLLER
+	select VIDEO_V4L2_SUBDEV_API
+	select V4L2_ASYNC
+	help
+	  This is a driver for the DW9714 camera lens voice coil.
+	  DW9714 is a 10 bit DAC with 120mA output current sink
+	  capability. This is designed for linear control of
+	  voice coil motors, controlled via I2C serial interface.
+
+config VIDEO_DW9768
+	tristate "DW9768 lens voice coil support"
+	depends on I2C && VIDEO_V4L2
+	select MEDIA_CONTROLLER
+	select VIDEO_V4L2_SUBDEV_API
+	select V4L2_FWNODE
+	help
+	  This is a driver for the DW9768 camera lens voice coil.
+	  DW9768 is a 10 bit DAC with 100mA output current sink
+	  capability. This is designed for linear control of
+	  voice coil motors, controlled via I2C serial interface.
+
+config VIDEO_DW9807_VCM
+	tristate "DW9807 lens voice coil support"
+	depends on I2C && VIDEO_V4L2
+	select MEDIA_CONTROLLER
+	select VIDEO_V4L2_SUBDEV_API
+	select V4L2_ASYNC
+	help
+	  This is a driver for the DW9807 camera lens voice coil.
+	  DW9807 is a 10 bit DAC with 100mA output current sink
+	  capability. This is designed for linear control of
+	  voice coil motors, controlled via I2C serial interface.
+
+endmenu
+
+menu "Flash devices"
+	visible if MEDIA_CAMERA_SUPPORT
+
+config VIDEO_ADP1653
+	tristate "ADP1653 flash support"
+	depends on I2C && VIDEO_V4L2
+	select MEDIA_CONTROLLER
+	select V4L2_ASYNC
+	help
+	  This is a driver for the ADP1653 flash controller. It is used for
+	  example in Nokia N900.
+
+config VIDEO_LM3560
+	tristate "LM3560 dual flash driver support"
+	depends on I2C && VIDEO_V4L2
+	select MEDIA_CONTROLLER
+	select REGMAP_I2C
+	select V4L2_ASYNC
+	help
+	  This is a driver for the lm3560 dual flash controllers. It controls
+	  flash, torch LEDs.
+
+config VIDEO_LM3646
+	tristate "LM3646 dual flash driver support"
+	depends on I2C && VIDEO_V4L2
+	select MEDIA_CONTROLLER
+	select REGMAP_I2C
+	select V4L2_ASYNC
+	help
+	  This is a driver for the lm3646 dual flash controllers. It controls
+	  flash, torch LEDs.
+endmenu
+
+endif # VIDEO_V4L2

--- a/build.sh
+++ b/build.sh
@@ -100,7 +100,7 @@ build_pi_kernel() {
         cp -r $RELEASE_PACK_DIR/driver_source/cam_drv_src/rpi-5.15_all/*.c ${LINUX_DIR}/drivers/media/i2c/
         cp -r $RELEASE_PACK_DIR/driver_source/cam_drv_src/rpi-5.15_all/*.h ${LINUX_DIR}/drivers/media/i2c/
         #copying the dts-files
-        cp -r $RELEASE_PACK_DIR/driver_source/cam_drv_src/dts/rpi-5.15.y/* ${LINUX_DIR}/linux/arch/arm/boot/dts/overlays/
+        cp -r $RELEASE_PACK_DIR/driver_source/dts/rpi-5.15.y/* ${LINUX_DIR}/linux/arch/arm/boot/dts/overlays/
 
 
         # yes "" | make oldconfig || exit 1

--- a/build.sh
+++ b/build.sh
@@ -91,6 +91,10 @@ build_pi_kernel() {
         # needs to be customised again in the future
         # cp "${CONFIGS}/.config-${KERNEL_BRANCH}-${ISA}" ./.config || exit 1
         make clean
+##veye v4l2
+git clone https://github.com/veyeimaging/raspberrypi_v4l2 workdir/mods/
+export RELEASE_PACK_DIR=$SRC_DIR/workdir/linux-pi 
+
         # yes "" | make oldconfig || exit 1
             if [[ "${ISA}" == "v7l" ]]; then
                 make clean
@@ -127,6 +131,9 @@ build_pi_kernel() {
     build_rtl8812au_driver
     build_rtl8812bu_driver 
     build_rtl8188eus_driver
+
+
+
     depmod -b ${PACKAGE_DIR} ${KERNEL_VERSION}
 
 }

--- a/build.sh
+++ b/build.sh
@@ -278,14 +278,14 @@ if [[ "${PLATFORM}" == "pi" ]]; then
     ls -a
     echo $(pwd)
         ##veye v4l2
-        git clone https://github.com/veyeimaging/raspberrypi_v4l2 workdir/mods/raspberrypi_v4l2
+        git clone https://github.com/openhd/raspberrypi_v4l2 workdir/mods/raspberrypi_v4l2
         export RELEASE_PACK_DIR=workdir/mods/raspberrypi_v4l2
         ls -a
         ls -a workdir/mods/raspberrypi_v4l2
         #copy drivers, not copying the makefile (the makefile will make the kernel not build)
         cp -r $RELEASE_PACK_DIR/driver_source/cam_drv_src/rpi-5.15_all/*.c workdir/linux-pi/drivers/media/i2c/
         cp -r $RELEASE_PACK_DIR/driver_source/cam_drv_src/rpi-5.15_all/*.h workdir/linux-pi/drivers/media/i2c/
-        echo 'obj-m += veye_mvcam.o veyecam2m.o csimx307.o cssc132.o' >> workdir/linux-pi/drivers/media/i2c/Makefile
+        echo 'obj-m += veye_mvcam.o veye327.o veyecam2m.o csimx307.o cssc132.o' >> workdir/linux-pi/drivers/media/i2c/Makefile
         cp -r additional/Kconfig workdir/linux-pi/drivers/media/i2c/
         #copying the dts-files
         cp -r $RELEASE_PACK_DIR/driver_source/dts/rpi-5.15.y/* workdir/linux-pi/arch/arm/boot/dts/overlays/
@@ -293,7 +293,7 @@ if [[ "${PLATFORM}" == "pi" ]]; then
         #sed -i '280 i csimx307-dual-cm4-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
         sed -i '280 i csimx307-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
         sed -i '281 i cssc132-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
-        sed -i '282 i veye_mvcam-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
+        sed -i '282 i veye327-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
         sed -i '283 i veyecam2m-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
         sed -i '280,283s/^/        /' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
         echo "Set Overlays"

--- a/build.sh
+++ b/build.sh
@@ -92,8 +92,8 @@ build_pi_kernel() {
         # cp "${CONFIGS}/.config-${KERNEL_BRANCH}-${ISA}" ./.config || exit 1
         make clean
 ##veye v4l2
-git clone https://github.com/veyeimaging/raspberrypi_v4l2 ../workdir/mods/
-export RELEASE_PACK_DIR=../workdir/linux-pi 
+git clone https://github.com/veyeimaging/raspberrypi_v4l2 ../mods/
+export RELEASE_PACK_DIR=../mods/
 echo $RELEASE_PACK_DIR
         # yes "" | make oldconfig || exit 1
             if [[ "${ISA}" == "v7l" ]]; then

--- a/build.sh
+++ b/build.sh
@@ -285,7 +285,7 @@ if [[ "${PLATFORM}" == "pi" ]]; then
         #copy drivers, not copying the makefile (the makefile will make the kernel not build)
         cp -r $RELEASE_PACK_DIR/driver_source/cam_drv_src/rpi-5.15_all/*.c workdir/linux-pi/drivers/media/i2c/
         cp -r $RELEASE_PACK_DIR/driver_source/cam_drv_src/rpi-5.15_all/*.h workdir/linux-pi/drivers/media/i2c/
-        echo 'obj-m := veye_mvcam.o veyecam2m.o csimx307.o cssc132.o' >> workdir/linux-pi/drivers/media/i2c/Makefile
+        echo 'obj-m += veye_mvcam.o veyecam2m.o csimx307.o cssc132.o' >> workdir/linux-pi/drivers/media/i2c/Makefile
         cp -r additional/Kconfig workdir/linux-pi/drivers/media/i2c/
         #copying the dts-files
         cp -r $RELEASE_PACK_DIR/driver_source/dts/rpi-5.15.y/* workdir/linux-pi/arch/arm/boot/dts/overlays/

--- a/build.sh
+++ b/build.sh
@@ -289,12 +289,12 @@ if [[ "${PLATFORM}" == "pi" ]]; then
         cp -r additional/Kconfig workdir/linux-pi/drivers/media/i2c/
         #copying the dts-files
         cp -r $RELEASE_PACK_DIR/driver_source/dts/rpi-5.15.y/* workdir/linux-pi/arch/arm/boot/dts/overlays/
-        sed -i '280 i csimx307-dual-cm4-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
+        #sed -i '280 i csimx307-dual-cm4-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
         sed -i '281 i csimx307-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
         sed -i '282 i cssc132-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
         sed -i '283 i veye_mvcam-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
         sed -i '284 i veyecam2m-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
-        sed -i '280,284s/^/       /' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
+        sed -i '280,284s/^/        /' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
         echo "Set Overlays"
 
     source $SRC_DIR/kernels/${PLATFORM}-${DISTRO}-v7

--- a/build.sh
+++ b/build.sh
@@ -285,7 +285,7 @@ if [[ "${PLATFORM}" == "pi" ]]; then
         #copy drivers, not copying the makefile (the makefile will make the kernel not build)
         cp -r $RELEASE_PACK_DIR/driver_source/cam_drv_src/rpi-5.15_all/*.c workdir/linux-pi/drivers/media/i2c/
         cp -r $RELEASE_PACK_DIR/driver_source/cam_drv_src/rpi-5.15_all/*.h workdir/linux-pi/drivers/media/i2c/
-        echo 'obj-m += veye_mvcam.o veye327.o csimx307.o cssc132.o' >> workdir/linux-pi/drivers/media/i2c/Makefile
+        echo 'obj-m += veye_mvcam.o veye327.o veyecam2m.o csimx307.o cssc132.o' >> workdir/linux-pi/drivers/media/i2c/Makefile
         cp -r additional/Kconfig workdir/linux-pi/drivers/media/i2c/
         #copying the dts-files
         cp -r $RELEASE_PACK_DIR/driver_source/dts/rpi-5.15.y/* workdir/linux-pi/arch/arm/boot/dts/overlays/
@@ -294,7 +294,9 @@ if [[ "${PLATFORM}" == "pi" ]]; then
         sed -i '280 i csimx307-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
         sed -i '281 i cssc132-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
         sed -i '282 i veye327-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
-        sed -i '280,282s/^/        /' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
+        sed -i '283 i veyecam2m-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
+        sed -i '284 i veye_mvcam-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
+        sed -i '280,284/^/        /' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
         echo "Set Overlays"
 
     source $SRC_DIR/kernels/${PLATFORM}-${DISTRO}-v7

--- a/build.sh
+++ b/build.sh
@@ -92,8 +92,8 @@ build_pi_kernel() {
         # cp "${CONFIGS}/.config-${KERNEL_BRANCH}-${ISA}" ./.config || exit 1
         make clean
 ##veye v4l2
-git clone https://github.com/veyeimaging/raspberrypi_v4l2 ../mods/
-export RELEASE_PACK_DIR=../mods/
+git clone https://github.com/veyeimaging/raspberrypi_v4l2 ../mods/raspberrypi_v4l2
+export RELEASE_PACK_DIR=../mods/raspberrypi_v4l2
 echo $RELEASE_PACK_DIR
         # yes "" | make oldconfig || exit 1
             if [[ "${ISA}" == "v7l" ]]; then

--- a/build.sh
+++ b/build.sh
@@ -289,11 +289,11 @@ if [[ "${PLATFORM}" == "pi" ]]; then
         cp -r additional/Kconfig workdir/linux-pi/drivers/media/i2c/
         #copying the dts-files
         cp -r $RELEASE_PACK_DIR/driver_source/dts/rpi-5.15.y/* workdir/linux-pi/arch/arm/boot/dts/overlays/
-        sed -i '280 i csimx307-dual-cm4-overlay.dts \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
-        sed -i '281 i csimx307-overlay.dts \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
-        sed -i '282 i cssc132-overlay.dts \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
-        sed -i '283 i veye_mvcam-overlay.dts \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
-        sed -i '284 i veyecam2m-overlay.dts \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
+        sed -i '280 i csimx307-dual-cm4-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
+        sed -i '281 i csimx307-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
+        sed -i '282 i cssc132-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
+        sed -i '283 i veye_mvcam-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
+        sed -i '284 i veyecam2m-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
         echo "Set Overlays"
 
     source $SRC_DIR/kernels/${PLATFORM}-${DISTRO}-v7

--- a/build.sh
+++ b/build.sh
@@ -99,7 +99,7 @@ build_pi_kernel() {
         #copy drivers, not copying the makefile (the makefile will make the kernel not build)
         cp -r $RELEASE_PACK_DIR/driver_source/cam_drv_src/rpi-5.15_all/*.c ${LINUX_DIR}/drivers/media/i2c/
         cp -r $RELEASE_PACK_DIR/driver_source/cam_drv_src/rpi-5.15_all/*.h ${LINUX_DIR}/drivers/media/i2c/
-        echo "obj-$(CONFIG_VIDEO_VEYE327) += veye_mvcam.o veyecam2m.o csimx307.o cssc132.o" >> ${LINUX_DIR}/drivers/media/i2c/MAKEFILE
+        echo 'obj-$(CONFIG_VIDEO_VEYE327) += veye_mvcam.o veyecam2m.o csimx307.o cssc132.o' >> ${LINUX_DIR}/drivers/media/i2c/MAKEFILE
         echo "CONFIG_VIDEO_VEYE327=y" >> ${LINUX_DIR}/arch/arm/configs/bcm2711_defconfig
         echo "CONFIG_VIDEO_VEYE327=y" >> ${LINUX_DIR}/arch/arm/configs/bcm2709_defconfig
         echo "CONFIG_VIDEO_VEYE327=y" >> ${LINUX_DIR}/arch/arm/configs/bcmrpi_defconfig

--- a/build.sh
+++ b/build.sh
@@ -99,6 +99,11 @@ build_pi_kernel() {
         #copy drivers, not copying the makefile (the makefile will make the kernel not build)
         cp -r $RELEASE_PACK_DIR/driver_source/cam_drv_src/rpi-5.15_all/*.c ${LINUX_DIR}/drivers/media/i2c/
         cp -r $RELEASE_PACK_DIR/driver_source/cam_drv_src/rpi-5.15_all/*.h ${LINUX_DIR}/drivers/media/i2c/
+        echo "obj-$(CONFIG_VIDEO_VEYE327) += veye_mvcam.o veyecam2m.o csimx307.o cssc132.o" >> ${LINUX_DIR}/drivers/media/i2c/MAKEFILE
+        echo "CONFIG_VIDEO_VEYE327=y" >> ${LINUX_DIR}/arch/arm/configs/bcm2711_defconfig
+        echo "CONFIG_VIDEO_VEYE327=y" >> ${LINUX_DIR}/arch/arm/configs/bcm2709_defconfig
+        echo "CONFIG_VIDEO_VEYE327=y" >> ${LINUX_DIR}/arch/arm/configs/bcmrpi_defconfig
+
         #copying the dts-files
         cp -r $RELEASE_PACK_DIR/driver_source/dts/rpi-5.15.y/* ${LINUX_DIR}/arch/arm/boot/dts/overlays/
 

--- a/build.sh
+++ b/build.sh
@@ -289,11 +289,11 @@ if [[ "${PLATFORM}" == "pi" ]]; then
         cp -r additional/Kconfig workdir/linux-pi/drivers/media/i2c/
         #copying the dts-files
         cp -r $RELEASE_PACK_DIR/driver_source/dts/rpi-5.15.y/* workdir/linux-pi/arch/arm/boot/dts/overlays/
-        sed -i '280 i csimx307-dual-cm4-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
-        sed -i '281 i csimx307-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
-        sed -i '282 i cssc132-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
-        sed -i '283 i veye_mvcam-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
-        sed -i '284 i veyecam2m-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
+        sed -i '280 i /     /csimx307-dual-cm4-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
+        sed -i '281 i /     /csimx307-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
+        sed -i '282 i /     /cssc132-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
+        sed -i '283 i /     /veye_mvcam-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
+        sed -i '284 i /     /veyecam2m-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
         echo "Set Overlays"
 
     source $SRC_DIR/kernels/${PLATFORM}-${DISTRO}-v7

--- a/build.sh
+++ b/build.sh
@@ -106,12 +106,12 @@ build_pi_kernel() {
 
         #copying the dts-files
         cp -r $RELEASE_PACK_DIR/driver_source/dts/rpi-5.15.y/* ${LINUX_DIR}/arch/arm/boot/dts/overlays/
-        sed '280 i csimx307-dual-cm4-overlay.dts \\' ${LINUX_DIR}/arch/arm/boot/dts/overlays/Makefile
-        sed '281 i csimx307-overlay.dts \\' ${LINUX_DIR}/arch/arm/boot/dts/overlays/Makefile
-        sed '282 i cssc132-overlay.dts \\' ${LINUX_DIR}/arch/arm/boot/dts/overlays/Makefile
-        sed '283 i veye_mvcam-overlay.dts \\' ${LINUX_DIR}/arch/arm/boot/dts/overlays/Makefile
-        sed '284 i veyecam2m-overlay.dts \\' ${LINUX_DIR}/arch/arm/boot/dts/overlays/Makefile
-
+        sed -i '280 i csimx307-dual-cm4-overlay.dts \\' ${LINUX_DIR}/arch/arm/boot/dts/overlays/Makefile
+        sed -i '281 i csimx307-overlay.dts \\' ${LINUX_DIR}/arch/arm/boot/dts/overlays/Makefile
+        sed -i '282 i cssc132-overlay.dts \\' ${LINUX_DIR}/arch/arm/boot/dts/overlays/Makefile
+        sed -i '283 i veye_mvcam-overlay.dts \\' ${LINUX_DIR}/arch/arm/boot/dts/overlays/Makefile
+        sed -i '284 i veyecam2m-overlay.dts \\' ${LINUX_DIR}/arch/arm/boot/dts/overlays/Makefile
+        echo "Set Overlays"
         # yes "" | make oldconfig || exit 1
             if [[ "${ISA}" == "v7l" ]]; then
                 make clean

--- a/build.sh
+++ b/build.sh
@@ -106,7 +106,11 @@ build_pi_kernel() {
 
         #copying the dts-files
         cp -r $RELEASE_PACK_DIR/driver_source/dts/rpi-5.15.y/* ${LINUX_DIR}/arch/arm/boot/dts/overlays/
-
+        sed '280 i csimx307-dual-cm4-overlay.dts \\' ${LINUX_DIR}/arch/arm/boot/dts/overlays/Makefile
+        sed '281 i csimx307-overlay.dts \\' ${LINUX_DIR}/arch/arm/boot/dts/overlays/Makefile
+        sed '282 i cssc132-overlay.dts \\' ${LINUX_DIR}/arch/arm/boot/dts/overlays/Makefile
+        sed '283 i veye_mvcam-overlay.dts \\' ${LINUX_DIR}/arch/arm/boot/dts/overlays/Makefile
+        sed '284 i veyecam2m-overlay.dts \\' ${LINUX_DIR}/arch/arm/boot/dts/overlays/Makefile
 
         # yes "" | make oldconfig || exit 1
             if [[ "${ISA}" == "v7l" ]]; then

--- a/build.sh
+++ b/build.sh
@@ -289,6 +289,7 @@ if [[ "${PLATFORM}" == "pi" ]]; then
         sed -i '954 i CONFIG_VIDEO_VEYE327=y' workdir/linux-pi/arch/arm/configs/bcm2711_defconfig
         sed -i '932 i CONFIG_VIDEO_VEYE327=y' workdir/linux-pi/arch/arm/configs/bcm2709_defconfig
         sed -i '932 i CONFIG_VIDEO_VEYE327=y' workdir/linux-pi/arch/arm/configs/bcmrpi_defconfig
+        cp -r additional/Kconfig workdir/linux-pi/drivers/media/i2c/
         #copying the dts-files
         cp -r $RELEASE_PACK_DIR/driver_source/dts/rpi-5.15.y/* workdir/linux-pi/arch/arm/boot/dts/overlays/
         sed -i '280 i csimx307-dual-cm4-overlay.dts \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile

--- a/build.sh
+++ b/build.sh
@@ -278,25 +278,25 @@ if [[ "${PLATFORM}" == "pi" ]]; then
     ls -a
     echo $(pwd)
         ##veye v4l2
-        git clone https://github.com/veyeimaging/raspberrypi_v4l2 mods/raspberrypi_v4l2
-        export RELEASE_PACK_DIR=${LINUX_DIR}/mods/raspberrypi_v4l2
+        git clone https://github.com/veyeimaging/raspberrypi_v4l2 workdir/mods/raspberrypi_v4l2
+        export RELEASE_PACK_DIR=workdir/mods/raspberrypi_v4l2
         ls -a
-        ls -a ${LINUX_DIR}/mods/raspberrypi_v4l2
+        ls -a workdir/mods/raspberrypi_v4l2
         #copy drivers, not copying the makefile (the makefile will make the kernel not build)
-        cp -r $RELEASE_PACK_DIR/driver_source/cam_drv_src/rpi-5.15_all/*.c ${LINUX_DIR}/drivers/media/i2c/
-        cp -r $RELEASE_PACK_DIR/driver_source/cam_drv_src/rpi-5.15_all/*.h ${LINUX_DIR}/drivers/media/i2c/
-        echo 'obj-$(CONFIG_VIDEO_VEYE327) += veye_mvcam.o veyecam2m.o csimx307.o cssc132.o' >> ${LINUX_DIR}/drivers/media/i2c/MAKEFILE
-        echo "CONFIG_VIDEO_VEYE327=y" >> ${LINUX_DIR}/arch/arm/configs/bcm2711_defconfig
-        echo "CONFIG_VIDEO_VEYE327=y" >> ${LINUX_DIR}/arch/arm/configs/bcm2709_defconfig
-        echo "CONFIG_VIDEO_VEYE327=y" >> ${LINUX_DIR}/arch/arm/configs/bcmrpi_defconfig
+        cp -r $RELEASE_PACK_DIR/driver_source/cam_drv_src/rpi-5.15_all/*.c workdir/linux-pi/drivers/media/i2c/
+        cp -r $RELEASE_PACK_DIR/driver_source/cam_drv_src/rpi-5.15_all/*.h workdir/linux-pi/drivers/media/i2c/
+        echo 'obj-$(CONFIG_VIDEO_VEYE327) += veye_mvcam.o veyecam2m.o csimx307.o cssc132.o' >> workdir/linux-pi/drivers/media/i2c/MAKEFILE
+        echo "CONFIG_VIDEO_VEYE327=y" >> workdir/linux-pi/arch/arm/configs/bcm2711_defconfig
+        echo "CONFIG_VIDEO_VEYE327=y" >> workdir/linux-pi/arch/arm/configs/bcm2709_defconfig
+        echo "CONFIG_VIDEO_VEYE327=y" >> workdir/linux-pi/arm/configs/bcmrpi_defconfig
 
         #copying the dts-files
-        cp -r $RELEASE_PACK_DIR/driver_source/dts/rpi-5.15.y/* ${LINUX_DIR}/arch/arm/boot/dts/overlays/
-        sed -i '280 i csimx307-dual-cm4-overlay.dts \\' ${LINUX_DIR}/arch/arm/boot/dts/overlays/Makefile
-        sed -i '281 i csimx307-overlay.dts \\' ${LINUX_DIR}/arch/arm/boot/dts/overlays/Makefile
-        sed -i '282 i cssc132-overlay.dts \\' ${LINUX_DIR}/arch/arm/boot/dts/overlays/Makefile
-        sed -i '283 i veye_mvcam-overlay.dts \\' ${LINUX_DIR}/arch/arm/boot/dts/overlays/Makefile
-        sed -i '284 i veyecam2m-overlay.dts \\' ${LINUX_DIR}/arch/arm/boot/dts/overlays/Makefile
+        cp -r $RELEASE_PACK_DIR/driver_source/dts/rpi-5.15.y/* workdir/linux-pi/arch/arm/boot/dts/overlays/
+        sed -i '280 i csimx307-dual-cm4-overlay.dts \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
+        sed -i '281 i csimx307-overlay.dts \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
+        sed -i '282 i cssc132-overlay.dts \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
+        sed -i '283 i veye_mvcam-overlay.dts \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
+        sed -i '284 i veyecam2m-overlay.dts \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
         echo "Set Overlays"
 
     source $SRC_DIR/kernels/${PLATFORM}-${DISTRO}-v7

--- a/build.sh
+++ b/build.sh
@@ -275,8 +275,8 @@ if [[ "${PLATFORM}" == "pi" ]]; then
     # note that pi zero kernels are not being generated here because they are prepackaged with a specific 
     # kernel build. this is a temporary thing due to the unique issues with USB on the pi zero.
     fetch_SBC_source
-    ls -a0
-    echo $PWD
+    ls -a
+    echo $(pwd)
         ##veye v4l2
         git clone https://github.com/veyeimaging/raspberrypi_v4l2 mods/raspberrypi_v4l2
         export RELEASE_PACK_DIR=${LINUX_DIR}/mods/raspberrypi_v4l2

--- a/build.sh
+++ b/build.sh
@@ -276,9 +276,8 @@ if [[ "${PLATFORM}" == "pi" ]]; then
     # kernel build. this is a temporary thing due to the unique issues with USB on the pi zero.
     fetch_SBC_source
         ##veye v4l2
-        git clone https://github.com/veyeimaging/raspberrypi_v4l2 ../mods/raspberrypi_v4l2
-        export RELEASE_PACK_DIR=${LINUX_DIR}/../mods/raspberrypi_v4l2
-        echo $RELEASE_PACK_DIR
+        git clone https://github.com/veyeimaging/raspberrypi_v4l2 mods/raspberrypi_v4l2
+        export RELEASE_PACK_DIR=${LINUX_DIR}/mods/raspberrypi_v4l2
         #copy drivers, not copying the makefile (the makefile will make the kernel not build)
         cp -r $RELEASE_PACK_DIR/driver_source/cam_drv_src/rpi-5.15_all/*.c ${LINUX_DIR}/drivers/media/i2c/
         cp -r $RELEASE_PACK_DIR/driver_source/cam_drv_src/rpi-5.15_all/*.h ${LINUX_DIR}/drivers/media/i2c/

--- a/build.sh
+++ b/build.sh
@@ -112,18 +112,18 @@ build_pi_kernel() {
         sed -i '283 i veye_mvcam-overlay.dts \\' ${LINUX_DIR}/arch/arm/boot/dts/overlays/Makefile
         sed -i '284 i veyecam2m-overlay.dts \\' ${LINUX_DIR}/arch/arm/boot/dts/overlays/Makefile
         echo "Set Overlays"
+        
         # yes "" | make oldconfig || exit 1
             if [[ "${ISA}" == "v7l" ]]; then
                 make clean
                 make bcm2711_defconfig
             elif [[ "${ISA}" == "v7" ]]; then
-            echo "debug"
-            #    make clean
-            #    make bcm2709_defconfig
+                make clean
+                make bcm2709_defconfig
             elif [[ "${ISA}" == "v6" ]]; then
             echo "debug"
-            #    make clean
-            #    make bcmrpi_defconfig
+                make clean
+                make bcmrpi_defconfig
             # currently only doing default config, modified config can follow later, but standart eases the possibility to upgrade to a newer kernel 
             fi
         KERNEL=${KERNEL} KBUILD_BUILD_TIMESTAMP='' make -j $J_CORES zImage modules dtbs || exit 1

--- a/build.sh
+++ b/build.sh
@@ -285,7 +285,7 @@ if [[ "${PLATFORM}" == "pi" ]]; then
         #copy drivers, not copying the makefile (the makefile will make the kernel not build)
         cp -r $RELEASE_PACK_DIR/driver_source/cam_drv_src/rpi-5.15_all/*.c workdir/linux-pi/drivers/media/i2c/
         cp -r $RELEASE_PACK_DIR/driver_source/cam_drv_src/rpi-5.15_all/*.h workdir/linux-pi/drivers/media/i2c/
-        echo 'obj-m += veye_mvcam.o veye327.o veyecam2m.o csimx307.o cssc132.o' >> workdir/linux-pi/drivers/media/i2c/Makefile
+        echo 'obj-m += veye_mvcam.o veye327.o csimx307.o cssc132.o' >> workdir/linux-pi/drivers/media/i2c/Makefile
         cp -r additional/Kconfig workdir/linux-pi/drivers/media/i2c/
         #copying the dts-files
         cp -r $RELEASE_PACK_DIR/driver_source/dts/rpi-5.15.y/* workdir/linux-pi/arch/arm/boot/dts/overlays/
@@ -294,7 +294,7 @@ if [[ "${PLATFORM}" == "pi" ]]; then
         sed -i '280 i csimx307-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
         sed -i '281 i cssc132-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
         sed -i '282 i veye327-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
-        sed -i '283 i veyecam2m-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
+        sed -i '283 i veyemvcam-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
         sed -i '280,283s/^/        /' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
         echo "Set Overlays"
 

--- a/build.sh
+++ b/build.sh
@@ -289,11 +289,12 @@ if [[ "${PLATFORM}" == "pi" ]]; then
         cp -r additional/Kconfig workdir/linux-pi/drivers/media/i2c/
         #copying the dts-files
         cp -r $RELEASE_PACK_DIR/driver_source/dts/rpi-5.15.y/* workdir/linux-pi/arch/arm/boot/dts/overlays/
-        sed -i '280 i /^/      /csimx307-dual-cm4-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
-        sed -i '281 i /^/      /csimx307-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
-        sed -i '282 i /^/      /cssc132-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
-        sed -i '283 i /^/      /veye_mvcam-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
-        sed -i '284 i /^/      /veyecam2m-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
+        sed -i '280 i csimx307-dual-cm4-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
+        sed -i '281 i csimx307-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
+        sed -i '282 i cssc132-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
+        sed -i '283 i veye_mvcam-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
+        sed -i '284 i veyecam2m-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
+        sed -i '280,284s/^/       /' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
         echo "Set Overlays"
 
     source $SRC_DIR/kernels/${PLATFORM}-${DISTRO}-v7

--- a/build.sh
+++ b/build.sh
@@ -92,27 +92,6 @@ build_pi_kernel() {
         # cp "${CONFIGS}/.config-${KERNEL_BRANCH}-${ISA}" ./.config || exit 1
         make clean
 
-        ##veye v4l2
-        git clone https://github.com/veyeimaging/raspberrypi_v4l2 ../mods/raspberrypi_v4l2
-        export RELEASE_PACK_DIR=${LINUX_DIR}/../mods/raspberrypi_v4l2
-        echo $RELEASE_PACK_DIR
-        #copy drivers, not copying the makefile (the makefile will make the kernel not build)
-        cp -r $RELEASE_PACK_DIR/driver_source/cam_drv_src/rpi-5.15_all/*.c ${LINUX_DIR}/drivers/media/i2c/
-        cp -r $RELEASE_PACK_DIR/driver_source/cam_drv_src/rpi-5.15_all/*.h ${LINUX_DIR}/drivers/media/i2c/
-        echo 'obj-$(CONFIG_VIDEO_VEYE327) += veye_mvcam.o veyecam2m.o csimx307.o cssc132.o' >> ${LINUX_DIR}/drivers/media/i2c/MAKEFILE
-        echo "CONFIG_VIDEO_VEYE327=y" >> ${LINUX_DIR}/arch/arm/configs/bcm2711_defconfig
-        echo "CONFIG_VIDEO_VEYE327=y" >> ${LINUX_DIR}/arch/arm/configs/bcm2709_defconfig
-        echo "CONFIG_VIDEO_VEYE327=y" >> ${LINUX_DIR}/arch/arm/configs/bcmrpi_defconfig
-
-        #copying the dts-files
-        cp -r $RELEASE_PACK_DIR/driver_source/dts/rpi-5.15.y/* ${LINUX_DIR}/arch/arm/boot/dts/overlays/
-        sed -i '280 i csimx307-dual-cm4-overlay.dts \\' ${LINUX_DIR}/arch/arm/boot/dts/overlays/Makefile
-        sed -i '281 i csimx307-overlay.dts \\' ${LINUX_DIR}/arch/arm/boot/dts/overlays/Makefile
-        sed -i '282 i cssc132-overlay.dts \\' ${LINUX_DIR}/arch/arm/boot/dts/overlays/Makefile
-        sed -i '283 i veye_mvcam-overlay.dts \\' ${LINUX_DIR}/arch/arm/boot/dts/overlays/Makefile
-        sed -i '284 i veyecam2m-overlay.dts \\' ${LINUX_DIR}/arch/arm/boot/dts/overlays/Makefile
-        echo "Set Overlays"
-        
         # yes "" | make oldconfig || exit 1
             if [[ "${ISA}" == "v7l" ]]; then
                 make clean
@@ -297,6 +276,27 @@ if [[ "${PLATFORM}" == "pi" ]]; then
     # note that pi zero kernels are not being generated here because they are prepackaged with a specific 
     # kernel build. this is a temporary thing due to the unique issues with USB on the pi zero.
     
+    ##veye v4l2
+        git clone https://github.com/veyeimaging/raspberrypi_v4l2 ../mods/raspberrypi_v4l2
+        export RELEASE_PACK_DIR=${LINUX_DIR}/../mods/raspberrypi_v4l2
+        echo $RELEASE_PACK_DIR
+        #copy drivers, not copying the makefile (the makefile will make the kernel not build)
+        cp -r $RELEASE_PACK_DIR/driver_source/cam_drv_src/rpi-5.15_all/*.c ${LINUX_DIR}/drivers/media/i2c/
+        cp -r $RELEASE_PACK_DIR/driver_source/cam_drv_src/rpi-5.15_all/*.h ${LINUX_DIR}/drivers/media/i2c/
+        echo 'obj-$(CONFIG_VIDEO_VEYE327) += veye_mvcam.o veyecam2m.o csimx307.o cssc132.o' >> ${LINUX_DIR}/drivers/media/i2c/MAKEFILE
+        echo "CONFIG_VIDEO_VEYE327=y" >> ${LINUX_DIR}/arch/arm/configs/bcm2711_defconfig
+        echo "CONFIG_VIDEO_VEYE327=y" >> ${LINUX_DIR}/arch/arm/configs/bcm2709_defconfig
+        echo "CONFIG_VIDEO_VEYE327=y" >> ${LINUX_DIR}/arch/arm/configs/bcmrpi_defconfig
+
+        #copying the dts-files
+        cp -r $RELEASE_PACK_DIR/driver_source/dts/rpi-5.15.y/* ${LINUX_DIR}/arch/arm/boot/dts/overlays/
+        sed -i '280 i csimx307-dual-cm4-overlay.dts \\' ${LINUX_DIR}/arch/arm/boot/dts/overlays/Makefile
+        sed -i '281 i csimx307-overlay.dts \\' ${LINUX_DIR}/arch/arm/boot/dts/overlays/Makefile
+        sed -i '282 i cssc132-overlay.dts \\' ${LINUX_DIR}/arch/arm/boot/dts/overlays/Makefile
+        sed -i '283 i veye_mvcam-overlay.dts \\' ${LINUX_DIR}/arch/arm/boot/dts/overlays/Makefile
+        sed -i '284 i veyecam2m-overlay.dts \\' ${LINUX_DIR}/arch/arm/boot/dts/overlays/Makefile
+        echo "Set Overlays"
+
     source $SRC_DIR/kernels/${PLATFORM}-${DISTRO}-v7
     prepare_build
     build_pi_kernel

--- a/build.sh
+++ b/build.sh
@@ -100,7 +100,7 @@ build_pi_kernel() {
         cp -r $RELEASE_PACK_DIR/driver_source/cam_drv_src/rpi-5.15_all/*.c ${LINUX_DIR}/drivers/media/i2c/
         cp -r $RELEASE_PACK_DIR/driver_source/cam_drv_src/rpi-5.15_all/*.h ${LINUX_DIR}/drivers/media/i2c/
         #copying the dts-files
-        cp -r $RELEASE_PACK_DIR/driver_source/dts/rpi-5.15.y/* ${LINUX_DIR}/linux/arch/arm/boot/dts/overlays/
+        cp -r $RELEASE_PACK_DIR/driver_source/dts/rpi-5.15.y/* ${LINUX_DIR}/arch/arm/boot/dts/overlays/
 
 
         # yes "" | make oldconfig || exit 1

--- a/build.sh
+++ b/build.sh
@@ -275,6 +275,8 @@ if [[ "${PLATFORM}" == "pi" ]]; then
     # note that pi zero kernels are not being generated here because they are prepackaged with a specific 
     # kernel build. this is a temporary thing due to the unique issues with USB on the pi zero.
     fetch_SBC_source
+    ls -a0
+    echo $PWD
         ##veye v4l2
         git clone https://github.com/veyeimaging/raspberrypi_v4l2 mods/raspberrypi_v4l2
         export RELEASE_PACK_DIR=${LINUX_DIR}/mods/raspberrypi_v4l2

--- a/build.sh
+++ b/build.sh
@@ -280,6 +280,8 @@ if [[ "${PLATFORM}" == "pi" ]]; then
         ##veye v4l2
         git clone https://github.com/veyeimaging/raspberrypi_v4l2 mods/raspberrypi_v4l2
         export RELEASE_PACK_DIR=${LINUX_DIR}/mods/raspberrypi_v4l2
+        ls -a
+        ls -a ${LINUX_DIR}/mods/raspberrypi_v4l2
         #copy drivers, not copying the makefile (the makefile will make the kernel not build)
         cp -r $RELEASE_PACK_DIR/driver_source/cam_drv_src/rpi-5.15_all/*.c ${LINUX_DIR}/drivers/media/i2c/
         cp -r $RELEASE_PACK_DIR/driver_source/cam_drv_src/rpi-5.15_all/*.h ${LINUX_DIR}/drivers/media/i2c/

--- a/build.sh
+++ b/build.sh
@@ -291,11 +291,11 @@ if [[ "${PLATFORM}" == "pi" ]]; then
         cp -r $RELEASE_PACK_DIR/driver_source/dts/rpi-5.15.y/* workdir/linux-pi/arch/arm/boot/dts/overlays/
         rm workdir/linux-pi/arch/arm/boot/dts/overlays/csimx307-dual-cm4-overlay*
         #sed -i '280 i csimx307-dual-cm4-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
-        sed -i '281 i csimx307-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
-        sed -i '282 i cssc132-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
-        sed -i '283 i veye_mvcam-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
-        sed -i '284 i veyecam2m-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
-        sed -i '281,284s/^/        /' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
+        sed -i '280 i csimx307-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
+        sed -i '281 i cssc132-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
+        sed -i '282 i veye_mvcam-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
+        sed -i '283 i veyecam2m-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
+        sed -i '280,283s/^/        /' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
         echo "Set Overlays"
 
     source $SRC_DIR/kernels/${PLATFORM}-${DISTRO}-v7

--- a/build.sh
+++ b/build.sh
@@ -295,7 +295,7 @@ if [[ "${PLATFORM}" == "pi" ]]; then
         sed -i '282 i cssc132-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
         sed -i '283 i veye_mvcam-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
         sed -i '284 i veyecam2m-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
-        sed -i '280,284s/^/        /' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
+        sed -i '281,284s/^/        /' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
         echo "Set Overlays"
 
     source $SRC_DIR/kernels/${PLATFORM}-${DISTRO}-v7

--- a/build.sh
+++ b/build.sh
@@ -286,10 +286,9 @@ if [[ "${PLATFORM}" == "pi" ]]; then
         cp -r $RELEASE_PACK_DIR/driver_source/cam_drv_src/rpi-5.15_all/*.c workdir/linux-pi/drivers/media/i2c/
         cp -r $RELEASE_PACK_DIR/driver_source/cam_drv_src/rpi-5.15_all/*.h workdir/linux-pi/drivers/media/i2c/
         echo 'obj-$(CONFIG_VIDEO_VEYE327) += veye_mvcam.o veyecam2m.o csimx307.o cssc132.o' >> workdir/linux-pi/drivers/media/i2c/Makefile
-        echo "CONFIG_VIDEO_VEYE327=y" >> workdir/linux-pi/arch/arm/configs/bcm2711_defconfig
-        echo "CONFIG_VIDEO_VEYE327=y" >> workdir/linux-pi/arch/arm/configs/bcm2709_defconfig
-        echo "CONFIG_VIDEO_VEYE327=y" >> workdir/linux-pi/arm/configs/bcmrpi_defconfig
-
+        sed -i '954 i CONFIG_VIDEO_VEYE327=y' workdir/linux-pi/arch/arm/configs/bcm2711_defconfig
+        sed -i '932 i CONFIG_VIDEO_VEYE327=y' workdir/linux-pi/arch/arm/configs/bcm2709_defconfig
+        sed -i '932 i CONFIG_VIDEO_VEYE327=y' workdir/linux-pi/arch/arm/configs/bcmrpi_defconfig
         #copying the dts-files
         cp -r $RELEASE_PACK_DIR/driver_source/dts/rpi-5.15.y/* workdir/linux-pi/arch/arm/boot/dts/overlays/
         sed -i '280 i csimx307-dual-cm4-overlay.dts \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile

--- a/build.sh
+++ b/build.sh
@@ -92,9 +92,9 @@ build_pi_kernel() {
         # cp "${CONFIGS}/.config-${KERNEL_BRANCH}-${ISA}" ./.config || exit 1
         make clean
 ##veye v4l2
-git clone https://github.com/veyeimaging/raspberrypi_v4l2 workdir/mods/
-export RELEASE_PACK_DIR=$SRC_DIR/workdir/linux-pi 
-
+git clone https://github.com/veyeimaging/raspberrypi_v4l2 ../workdir/mods/
+export RELEASE_PACK_DIR=../workdir/linux-pi 
+echo $RELEASE_PACK_DIR
         # yes "" | make oldconfig || exit 1
             if [[ "${ISA}" == "v7l" ]]; then
                 make clean

--- a/build.sh
+++ b/build.sh
@@ -285,7 +285,7 @@ if [[ "${PLATFORM}" == "pi" ]]; then
         #copy drivers, not copying the makefile (the makefile will make the kernel not build)
         cp -r $RELEASE_PACK_DIR/driver_source/cam_drv_src/rpi-5.15_all/*.c workdir/linux-pi/drivers/media/i2c/
         cp -r $RELEASE_PACK_DIR/driver_source/cam_drv_src/rpi-5.15_all/*.h workdir/linux-pi/drivers/media/i2c/
-        echo 'obj-$(CONFIG_VIDEO_VEYE327) += veye_mvcam.o veyecam2m.o csimx307.o cssc132.o' >> workdir/linux-pi/drivers/media/i2c/MAKEFILE
+        echo 'obj-$(CONFIG_VIDEO_VEYE327) += veye_mvcam.o veyecam2m.o csimx307.o cssc132.o' >> workdir/linux-pi/drivers/media/i2c/Makefile
         echo "CONFIG_VIDEO_VEYE327=y" >> workdir/linux-pi/arch/arm/configs/bcm2711_defconfig
         echo "CONFIG_VIDEO_VEYE327=y" >> workdir/linux-pi/arch/arm/configs/bcm2709_defconfig
         echo "CONFIG_VIDEO_VEYE327=y" >> workdir/linux-pi/arm/configs/bcmrpi_defconfig

--- a/build.sh
+++ b/build.sh
@@ -294,8 +294,7 @@ if [[ "${PLATFORM}" == "pi" ]]; then
         sed -i '280 i csimx307-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
         sed -i '281 i cssc132-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
         sed -i '282 i veye327-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
-        sed -i '283 i veyemvcam-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
-        sed -i '280,283s/^/        /' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
+        sed -i '280,282s/^/        /' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
         echo "Set Overlays"
 
     source $SRC_DIR/kernels/${PLATFORM}-${DISTRO}-v7

--- a/build.sh
+++ b/build.sh
@@ -91,20 +91,28 @@ build_pi_kernel() {
         # needs to be customised again in the future
         # cp "${CONFIGS}/.config-${KERNEL_BRANCH}-${ISA}" ./.config || exit 1
         make clean
-##veye v4l2
-git clone https://github.com/veyeimaging/raspberrypi_v4l2 ../mods/raspberrypi_v4l2
-export RELEASE_PACK_DIR=../mods/raspberrypi_v4l2
-echo $RELEASE_PACK_DIR
+
+        ##veye v4l2
+        git clone https://github.com/veyeimaging/raspberrypi_v4l2 ../mods/raspberrypi_v4l2
+        export RELEASE_PACK_DIR=${LINUX_DIR}/../mods/raspberrypi_v4l2
+        echo $RELEASE_PACK_DIR
+        #copy drivers, not copying the makefile (the makefile will make the kernel not build)
+        cp -r $RELEASE_PACK_DIR/driver_source/cam_drv_src/rpi-5.15_all/*.c ${LINUX_DIR}/drivers/media/i2c/
+        cp -r $RELEASE_PACK_DIR/driver_source/cam_drv_src/rpi-5.15_all/*.h ${LINUX_DIR}/drivers/media/i2c/
+        #copying the dts-files
+        cp -r $RELEASE_PACK_DIR/driver_source/cam_drv_src/dts/rpi-5.15.y/* ${LINUX_DIR}/linux/arch/arm/boot/dts/overlays/
+
+
         # yes "" | make oldconfig || exit 1
             if [[ "${ISA}" == "v7l" ]]; then
                 make clean
                 make bcm2711_defconfig
             elif [[ "${ISA}" == "v7" ]]; then
-                make clean
-                make bcm2709_defconfig
+            #    make clean
+            #    make bcm2709_defconfig
             elif [[ "${ISA}" == "v6" ]]; then
-                make clean
-                make bcmrpi_defconfig
+            #    make clean
+            #    make bcmrpi_defconfig
         # currently only doing default config, modified config can follow later, but standart eases the possibility to upgrade to a newer kernel 
             fi
         KERNEL=${KERNEL} KBUILD_BUILD_TIMESTAMP='' make -j $J_CORES zImage modules dtbs || exit 1

--- a/build.sh
+++ b/build.sh
@@ -289,6 +289,7 @@ if [[ "${PLATFORM}" == "pi" ]]; then
         cp -r additional/Kconfig workdir/linux-pi/drivers/media/i2c/
         #copying the dts-files
         cp -r $RELEASE_PACK_DIR/driver_source/dts/rpi-5.15.y/* workdir/linux-pi/arch/arm/boot/dts/overlays/
+        rm workdir/linux-pi/arch/arm/boot/dts/overlays/csimx307-dual-cm4-overlay*
         #sed -i '280 i csimx307-dual-cm4-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
         sed -i '281 i csimx307-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
         sed -i '282 i cssc132-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile

--- a/build.sh
+++ b/build.sh
@@ -248,7 +248,6 @@ prepare_build() {
     if [[ "${PLATFORM}" == "pi" ]]; then
     check_time
     mkdir -p $SRC_DIR/workdir/mods/
-    fetch_SBC_source
     cd $SRC_DIR/workdir/mods/
     fetch_rtl8812au_driver
     fetch_rtl8812bu_driver
@@ -275,8 +274,8 @@ if [[ "${PLATFORM}" == "pi" ]]; then
     # a simple hack, we want 2 kernels in one package so we source 2 different configs and build them all.
     # note that pi zero kernels are not being generated here because they are prepackaged with a specific 
     # kernel build. this is a temporary thing due to the unique issues with USB on the pi zero.
-    
-    ##veye v4l2
+    fetch_SBC_source
+        ##veye v4l2
         git clone https://github.com/veyeimaging/raspberrypi_v4l2 ../mods/raspberrypi_v4l2
         export RELEASE_PACK_DIR=${LINUX_DIR}/../mods/raspberrypi_v4l2
         echo $RELEASE_PACK_DIR

--- a/build.sh
+++ b/build.sh
@@ -289,11 +289,11 @@ if [[ "${PLATFORM}" == "pi" ]]; then
         cp -r additional/Kconfig workdir/linux-pi/drivers/media/i2c/
         #copying the dts-files
         cp -r $RELEASE_PACK_DIR/driver_source/dts/rpi-5.15.y/* workdir/linux-pi/arch/arm/boot/dts/overlays/
-        sed -i '280 i /     /csimx307-dual-cm4-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
-        sed -i '281 i /     /csimx307-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
-        sed -i '282 i /     /cssc132-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
-        sed -i '283 i /     /veye_mvcam-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
-        sed -i '284 i /     /veyecam2m-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
+        sed -i '280 i /^/      /csimx307-dual-cm4-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
+        sed -i '281 i /^/      /csimx307-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
+        sed -i '282 i /^/      /cssc132-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
+        sed -i '283 i /^/      /veye_mvcam-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
+        sed -i '284 i /^/      /veyecam2m-overlay.dtbo \\' workdir/linux-pi/arch/arm/boot/dts/overlays/Makefile
         echo "Set Overlays"
 
     source $SRC_DIR/kernels/${PLATFORM}-${DISTRO}-v7

--- a/build.sh
+++ b/build.sh
@@ -108,12 +108,14 @@ build_pi_kernel() {
                 make clean
                 make bcm2711_defconfig
             elif [[ "${ISA}" == "v7" ]]; then
+            echo "debug"
             #    make clean
             #    make bcm2709_defconfig
             elif [[ "${ISA}" == "v6" ]]; then
+            echo "debug"
             #    make clean
             #    make bcmrpi_defconfig
-        # currently only doing default config, modified config can follow later, but standart eases the possibility to upgrade to a newer kernel 
+            # currently only doing default config, modified config can follow later, but standart eases the possibility to upgrade to a newer kernel 
             fi
         KERNEL=${KERNEL} KBUILD_BUILD_TIMESTAMP='' make -j $J_CORES zImage modules dtbs || exit 1
 

--- a/build.sh
+++ b/build.sh
@@ -285,10 +285,7 @@ if [[ "${PLATFORM}" == "pi" ]]; then
         #copy drivers, not copying the makefile (the makefile will make the kernel not build)
         cp -r $RELEASE_PACK_DIR/driver_source/cam_drv_src/rpi-5.15_all/*.c workdir/linux-pi/drivers/media/i2c/
         cp -r $RELEASE_PACK_DIR/driver_source/cam_drv_src/rpi-5.15_all/*.h workdir/linux-pi/drivers/media/i2c/
-        echo 'obj-$(CONFIG_VIDEO_VEYE327) += veye_mvcam.o veyecam2m.o csimx307.o cssc132.o' >> workdir/linux-pi/drivers/media/i2c/Makefile
-        sed -i '954 i CONFIG_VIDEO_VEYE327=y' workdir/linux-pi/arch/arm/configs/bcm2711_defconfig
-        sed -i '932 i CONFIG_VIDEO_VEYE327=y' workdir/linux-pi/arch/arm/configs/bcm2709_defconfig
-        sed -i '932 i CONFIG_VIDEO_VEYE327=y' workdir/linux-pi/arch/arm/configs/bcmrpi_defconfig
+        echo 'obj-m := veye_mvcam.o veyecam2m.o csimx307.o cssc132.o' >> workdir/linux-pi/drivers/media/i2c/Makefile
         cp -r additional/Kconfig workdir/linux-pi/drivers/media/i2c/
         #copying the dts-files
         cp -r $RELEASE_PACK_DIR/driver_source/dts/rpi-5.15.y/* workdir/linux-pi/arch/arm/boot/dts/overlays/


### PR DESCRIPTION
Add Veye v4l2 drivers , including a ported driver for imx290/327 (for older hw-revisions)