### PR TITLE
Fix imx662 probe signature for legacy I2C registration

### DIFF
--- a/additional/imx662/imx662.c
+++ b/additional/imx662/imx662.c
@@ -1018,7 +1018,8 @@ static const struct of_device_id imx662_of_match[] = {
 	{ /* sentinel */ }
 };
 
-static int imx662_probe(struct i2c_client *client)
+static int imx662_probe(struct i2c_client *client,
+		const struct i2c_device_id *id)
 {
 	struct v4l2_fwnode_device_properties props;
 	struct device *dev = &client->dev;
@@ -1034,6 +1035,9 @@ static int imx662_probe(struct i2c_client *client)
 	u32 xclk_freq;
 	s64 fq;
 	int ret;
+
+	/* Suppress unused parameter warning on kernels that still pass @id */
+	(void)id;
 
 	imx662 = devm_kzalloc(dev, sizeof(*imx662), GFP_KERNEL);
 	if (!imx662)


### PR DESCRIPTION
## Summary
- adjust the imx662 probe prototype to match the legacy i2c_driver probe callback signature
- ignore the unused i2c_device_id argument so OF-only builds continue to compile cleanly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f9803b64ac832f9dc232b097c5ec93