### PR TITLE
Add missing IMX662 link frequencies to overlay

### DIFF
--- a/additional/imx662/imx662-overlay.dts
+++ b/additional/imx662/imx662-overlay.dts
@@ -8,21 +8,21 @@
 
 	fragment@0 {
 		target = <&cam_endpoint>;
-		__overlay__ {
-			data-lanes = <1 2>;
-			link-frequencies =
-				/bits/ 64 <594000000>;
-		};
-	};
+                __overlay__ {
+                        data-lanes = <1 2>;
+                        link-frequencies =
+                                /bits/ 64 <594000000 891000000 1188000000>;
+                };
+        };
 
 	fragment@1 {
 		target = <&cam_endpoint>;
-		__dormant__ {
-			data-lanes = <1 2 3 4>;
-			link-frequencies =
-				/bits/ 64 <297000000>;
-		};
-	};
+                __dormant__ {
+                        data-lanes = <1 2 3 4>;
+                        link-frequencies =
+                                /bits/ 64 <297000000 445500000 594000000>;
+                };
+        };
 
 	fragment@2 {
 		target = <&csi_ep>;


### PR DESCRIPTION
## Summary
- include every link frequency used by the IMX662 2-lane configuration
- extend the dormant 4-lane override with the matching set of link frequencies

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fabf2f8ffc832f9317468e1b9eaf66