### PR TITLE
Fix IMX662 overlay link frequencies

### DIFF
--- a/additional/imx662/imx662-overlay.dts
+++ b/additional/imx662/imx662-overlay.dts
@@ -8,11 +8,11 @@
 
 	fragment@0 {
 		target = <&cam_endpoint>;
-		__overlay__ {
-			data-lanes = <1 2>;
-			link-frequencies =
-				/bits/ 64 <594000000>;
-		};
+                __overlay__ {
+                        data-lanes = <1 2>;
+                        link-frequencies =
+                                /bits/ 64 <594000000 891000000 1188000000>;
+                };
 	};
 
 	fragment@1 {


### PR DESCRIPTION
## Summary
- include all supported 2-lane link frequencies in the IMX662 overlay so the driver accepts every mode

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fabf2f8ffc832f9317468e1b9eaf66