### PR TITLE
Add workflow to build IMX662 driver artifacts

### DIFF
--- a/.github/workflows/imx662-driver-test.yml
+++ b/.github/workflows/imx662-driver-test.yml
@@ -1,0 +1,40 @@
+name: imx662 driver build test
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build-imx662:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            bc \
+            bison \
+            device-tree-compiler \
+            flex \
+            gcc-arm-linux-gnueabihf \
+            g++-arm-linux-gnueabihf \
+            git \
+            kmod \
+            libncurses-dev \
+            libssl-dev \
+            make
+
+      - name: Build IMX662 module and overlay
+        run: |
+          bash scripts/build_imx662_module.sh
+
+      - name: Upload IMX662 artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: imx662-build-artifacts
+          path: artifacts/imx662
+          if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ v4l2loopback
 workdir
 .config
 *.log
+artifacts/
 
 arm-linux-gnueabihf-c\+\+
 

--- a/scripts/build_imx662_module.sh
+++ b/scripts/build_imx662_module.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+WORKDIR="${ROOT_DIR}/workdir/imx662-test"
+KERNEL_DIR="${WORKDIR}/linux-pi"
+MODULE_BUILD_DIR="${WORKDIR}/imx662-module"
+ARTIFACT_DIR="${ROOT_DIR}/artifacts/imx662"
+KERNEL_REPO="https://github.com/OpenHD/linux.git"
+KERNEL_BRANCH="rpi-6.1-stable"
+KERNEL_COMMIT="20cb6d7b533b5e6d7df8a2cb7a83bd4555834bde"
+CROSS_COMPILE_TOOLCHAIN="${CROSS_COMPILE:-arm-linux-gnueabihf-}"
+
+rm -rf "${WORKDIR}"
+rm -rf "${ARTIFACT_DIR}"
+mkdir -p "${WORKDIR}"
+mkdir -p "${ARTIFACT_DIR}"
+
+# Fetch the kernel source that matches the main build configuration.
+echo "Cloning kernel source..."
+git clone --depth 1 --branch "${KERNEL_BRANCH}" "${KERNEL_REPO}" "${KERNEL_DIR}"
+pushd "${KERNEL_DIR}" >/dev/null
+# Ensure the expected commit is available even when cloning with depth 1.
+git fetch --depth 1 origin "${KERNEL_COMMIT}"
+git checkout "${KERNEL_COMMIT}"
+
+export ARCH=arm
+export CROSS_COMPILE="${CROSS_COMPILE_TOOLCHAIN}"
+
+# Prepare the kernel for external module compilation.
+make bcm2711_defconfig
+make modules_prepare
+popd >/dev/null
+
+mkdir -p "${MODULE_BUILD_DIR}"
+cp "${ROOT_DIR}/additional/imx662/imx662.c" "${MODULE_BUILD_DIR}/"
+cat <<'MAKEFILE' > "${MODULE_BUILD_DIR}/Makefile"
+obj-m += imx662.o
+MAKEFILE
+
+# Build the IMX662 kernel module.
+make -C "${KERNEL_DIR}" ARCH=arm CROSS_COMPILE="${CROSS_COMPILE_TOOLCHAIN}" M="${MODULE_BUILD_DIR}" modules
+
+# Build the device tree overlay using the kernel build system.
+cp "${ROOT_DIR}/additional/imx662/imx662-overlay.dts" "${KERNEL_DIR}/arch/arm/boot/dts/overlays/"
+if ! grep -q "imx662-overlay.dtbo" "${KERNEL_DIR}/arch/arm/boot/dts/overlays/Makefile"; then
+  KERNEL_MAKEFILE_PATH="${KERNEL_DIR}/arch/arm/boot/dts/overlays/Makefile" \
+  python3 - <<'PY'
+from pathlib import Path
+import os
+makefile = Path(os.environ["KERNEL_MAKEFILE_PATH"])
+content = makefile.read_text()
+needle = "dtbo-$(CONFIG_ARCH_BCM2835) += imx662-overlay.dtbo\n"
+if needle not in content:
+    replacement = "dtbo-$(CONFIG_ARCH_BCM2835) += imx662-overlay.dtbo\n\ntargets += dtbs dtbs_install"
+    content = content.replace("targets += dtbs dtbs_install", replacement, 1)
+    makefile.write_text(content)
+PY
+fi
+make -C "${KERNEL_DIR}" ARCH=arm CROSS_COMPILE="${CROSS_COMPILE_TOOLCHAIN}" dtbs
+
+cp "${MODULE_BUILD_DIR}/imx662.ko" "${ARTIFACT_DIR}/"
+cp "${ROOT_DIR}/additional/imx662/imx662-overlay.dts" "${ARTIFACT_DIR}/"
+cp "${KERNEL_DIR}/arch/arm/boot/dts/overlays/imx662-overlay.dtbo" "${ARTIFACT_DIR}/"
+
+# Provide a quick summary for the CI logs.
+echo "Generated artifacts:"
+ls -l "${ARTIFACT_DIR}"


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that builds the Raspberry Pi IMX662 driver and uploads the outputs
- add a helper script to compile the IMX662 module and overlay while collecting artifacts
- ignore the generated artifacts directory to keep the tree clean

## Testing
- bash scripts/build_imx662_module.sh

------
https://chatgpt.com/codex/tasks/task_e_68fb6d1449b8832fb9c877407c674340