### PR TITLE
Fix rtl8812cu driver build and improve caching

### DIFF
--- a/.github/workflows/buildPi.yml
+++ b/.github/workflows/buildPi.yml
@@ -41,6 +41,9 @@ jobs:
           ccache --set-config=compiler_check=content && ccache --set-config=hash_dir=false
           echo "DT=$(date +'%Y-%m-%d_%H%M')" >> $GITHUB_ENV
           echo "BRANCH=${GITHUB_REF##*/}" >> $GITHUB_ENV
+          echo "CCACHE_DIR=$HOME/.ccache" >> $GITHUB_ENV
+          echo "CCACHE_BASEDIR=$GITHUB_WORKSPACE" >> $GITHUB_ENV
+          echo "CCACHE_WRAPPER_DIR=$HOME/.cache/ccache/bin" >> $GITHUB_ENV
       
       - name: Setup cache
         id: cache
@@ -54,7 +57,7 @@ jobs:
             
       - name: Build ${{ matrix.PLATFORM }} ${{ matrix.DISTRO }}
         run: |
-          export PATH=/usr/lib/ccache:$PATH
+          export PATH=$CCACHE_WRAPPER_DIR:/usr/lib/ccache:$PATH
           bash buildwithlog.sh ${{ matrix.PLATFORM }} ${{ matrix.DISTRO }} ONLINE
           
       - name: Compose release filename

--- a/build.sh
+++ b/build.sh
@@ -67,6 +67,10 @@ SRC_DIR=$(pwd)
 CONFIGS=$(pwd)/configs
 J_CORES=$(nproc)
 PACKAGE_DIR=$(pwd)/package
+export CCACHE_DIR=${CCACHE_DIR:-$HOME/.ccache}
+export CCACHE_BASEDIR=${CCACHE_BASEDIR:-${SRC_DIR}}
+export CCACHE_NOHASHDIR=1
+export CCACHE_COMPILERCHECK=${CCACHE_COMPILERCHECK:-content}
 
 # load helper scripts
 for File in scripts/*.sh; do
@@ -259,7 +263,7 @@ prepare_build() {
     cd $SRC_DIR/workdir/mods/
     fetch_rtl8812au_driver
     fetch_rtl8812bu_driver
-    # fetch_rtl8812cu_driver
+    fetch_rtl8812cu_driver
     fetch_rtl8812eu_driver
     #fetch_rtl8188eus_driver
     fetch_v4l2loopback_driver

--- a/scripts/platform.sh
+++ b/scripts/platform.sh
@@ -1,28 +1,31 @@
 #!/bin/bash
 
+function setup_ccache_prefix() {
+        local prefix=$1
+        local wrapper_dir=${CCACHE_WRAPPER_DIR:-${HOME}/.cache/ccache/bin}
+
+        mkdir -p "${wrapper_dir}"
+
+        pushd "${wrapper_dir}" >/dev/null
+                for tool in gcc g++ cpp cc; do
+                        ln -fs "$(which ccache)" "${prefix}${tool}"
+                done
+        popd >/dev/null
+
+        if [[ ${PATH} != *${wrapper_dir}* ]]; then
+                export PATH=${wrapper_dir}:${PATH}
+        fi
+}
+
 function setup_platform_env() {
-	if [[ "${PLATFORM}" == "pi" ]]; then
-		# CCACHE workaround
-		CCACHE_PATH=${PI_TOOLS_COMPILER_PATH}/../bin-ccache
+        if [[ "${PLATFORM}" == "pi" ]]; then
+                export ARCH=arm
+                PACKAGE_ARCH=armhf
+                export CROSS_COMPILE=arm-linux-gnueabihf-
+                KERNEL_REPO=https://github.com/OpenHD/linux.git
 
-		if [[ ! "$(ls -A ${CCACHE_PATH})" ]]; then
-			mkdir -p ${CCACHE_PATH}
-			pushd ${CCACHE_PATH}
-			ln -fs $(which ccache) arm-linux-gnueabihf-gcc
-			ln -fs $(which ccache) arm-linux-gnueabihf-g++
-			ln -fs $(which ccache) arm-linux-gnueabihf-cpp
-			ln -fs $(which ccache) arm-linux-gnueabihf-c++
-			popd
-		fi
-		if [[ ${PATH} != *${CCACHE_PATH}* ]]; then
-			export PATH=${CCACHE_PATH}:${PATH}
-		fi
-
-		export ARCH=arm
-		PACKAGE_ARCH=armhf
-		export CROSS_COMPILE=arm-linux-gnueabihf-
-		KERNEL_REPO=https://github.com/OpenHD/linux.git
-	fi
+                setup_ccache_prefix "${CROSS_COMPILE}"
+        fi
 
 	if [[ "${PLATFORM}" == "jetson" ]]; then
 		

--- a/scripts/realtek.sh
+++ b/scripts/realtek.sh
@@ -2,7 +2,7 @@
 
 function fetch_rtl8812au_driver() {
 
-    if [[ ! "$(ls -A rtl8812au)" ]]; then    
+    if [[ ! "$(ls -A rtl8812au)" ]]; then
         echo "Download the rtl8812au driver"
         git clone ${RTL_8812AU_REPO}
     fi
@@ -12,18 +12,18 @@ function fetch_rtl8812au_driver() {
         git reset --hard || exit 1
         git checkout ${RTL_8812AU_BRANCH} || exit 1
         git pull || exit 1
-   
+
         if [[ "${PLATFORM}" == "pi" ]]; then
             sed -i 's/CONFIG_PLATFORM_I386_PC = y/CONFIG_PLATFORM_I386_PC = n/' Makefile || exit 1
             sed -i 's/CONFIG_PLATFORM_ARM_RPI = n/CONFIG_PLATFORM_ARM_RPI = y/' Makefile || exit 1
         fi
 
-	if [[ "${PLATFORM}" == "jetson" ]]; then
-	    sed -i 's/CONFIG_PLATFORM_I386_PC = y/CONFIG_PLATFORM_I386_PC = n/g' Makefile || exit 1
-	    sed -i 's/CONFIG_PLATFORM_ARM64_RPI = n/CONFIG_PLATFORM_ARM64_RPI = y/g' Makefile || exit 1
-	    echo "jetsonSBC"
+        if [[ "${PLATFORM}" == "jetson" ]]; then
+            sed -i 's/CONFIG_PLATFORM_I386_PC = y/CONFIG_PLATFORM_I386_PC = n/g' Makefile || exit 1
+            sed -i 's/CONFIG_PLATFORM_ARM64_RPI = n/CONFIG_PLATFORM_ARM64_RPI = y/g' Makefile || exit 1
+            echo "jetsonSBC"
         fi
-	
+
 
         pushd core
             # Change the STBC value to make all antennas send with awus036ACH
@@ -36,39 +36,44 @@ function fetch_rtl8812au_driver() {
 function build_rtl8812au_driver() {
     pushd rtl8812au
         make clean
-	
-	if [[ "${PLATFORM}" == "pi" ]]; then
+
+        if [[ "${PLATFORM}" == "pi" ]]; then
          make KSRC=${LINUX_DIR} -j $J_CORES M=$(pwd) modules || exit 1
-	 mkdir -p ${PACKAGE_DIR}/lib/modules/${KERNEL_VERSION}/kernel/drivers/net/wireless/realtek/rtl8812au || exit 1
+         mkdir -p ${PACKAGE_DIR}/lib/modules/${KERNEL_VERSION}/kernel/drivers/net/wireless/realtek/rtl8812au || exit 1
          install -p -m 644 88XXau_ohd.ko "${PACKAGE_DIR}/lib/modules/${KERNEL_VERSION}/kernel/drivers/net/wireless/realtek/rtl8812au/88XXau_wfb.ko" || exit 1
-    
+
         fi
-	
-	if [[ "${PLATFORM}" == "jetson" ]]; then
-		export KERNEL_VERSION="4.9.253OpenHD-2.1-tegra"
-		export CROSS_COMPILE=$Tools/gcc-linaro-7.3.1-2018.05-x86_64_aarch64-linux-gnu/bin/aarch64-linux-gnu-
-	        make KSRC=${LINUX_DIR}/build -j $J_CORES M=$(pwd) modules || exit 1
-		mkdir -p ${PACKAGE_DIR}/lib/modules/${KERNEL_VERSION}/kernel/drivers/net/wireless/realtek/rtl8812au || exit 1
-		rm $SRC_DIR/workdir/Linux_for_Tegra/source/public/kernel/nvidia/drivers/net/wireless/realtek/rtl8812au/rtl8812au.ko
-         	install -p -m 644 88XXau_ohd.ko "${PACKAGE_DIR}/lib/modules/${KERNEL_VERSION}/kernel/drivers/net/wireless/realtek/rtl8812au/rtl8812au.ko" || exit 1
-	fi
+
+        if [[ "${PLATFORM}" == "jetson" ]]; then
+                export KERNEL_VERSION="4.9.253OpenHD-2.1-tegra"
+                export CROSS_COMPILE=$Tools/gcc-linaro-7.3.1-2018.05-x86_64_aarch64-linux-gnu/bin/aarch64-linux-gnu-
+                make KSRC=${LINUX_DIR}/build -j $J_CORES M=$(pwd) modules || exit 1
+                mkdir -p ${PACKAGE_DIR}/lib/modules/${KERNEL_VERSION}/kernel/drivers/net/wireless/realtek/rtl8812au || exit 1
+                rm $SRC_DIR/workdir/Linux_for_Tegra/source/public/kernel/nvidia/drivers/net/wireless/realtek/rtl8812au/rtl8812au.ko
+                install -p -m 644 88XXau_ohd.ko "${PACKAGE_DIR}/lib/modules/${KERNEL_VERSION}/kernel/drivers/net/wireless/realtek/rtl8812au/rtl8812au.ko" || exit 1
+        fi
 
 
        popd
 }
 
-function fetch_rtl8812bu_driver() {
+function prepare_rtl88x2_repo() {
 
-    if [[ ! "$(ls -A rtl88x2bu)" ]]; then    
-        echo "Download the rtl8812bu driver"
-        git clone ${RTL_8812BU_REPO} || exit 1
+    local repo_dir=$1
+    local repo=$2
+    local branch=$3
+    local driver_folder=$4
+
+    if [[ ! -d ${repo_dir} || -z "$(ls -A ${repo_dir} 2>/dev/null)" ]]; then
+        echo "Download the ${repo_dir} driver"
+        git clone ${repo} ${repo_dir} || exit 1
     fi
 
-    pushd rtl88x2bu
-        git fetch || exit 1
+    pushd ${repo_dir}
+        git fetch --all --tags || exit 1
         git reset --hard || exit 1
-        git checkout ${RTL_8812BU_BRANCH} || exit 1
-        git pull || exit 1
+        git checkout ${branch} || exit 1
+        git pull --ff-only || exit 1
 
         if [[ "${PLATFORM}" == "pi" ]]; then
             sed -i 's/CONFIG_PLATFORM_I386_PC = y/CONFIG_PLATFORM_I386_PC = n/' Makefile || exit 1
@@ -78,112 +83,61 @@ function fetch_rtl8812bu_driver() {
         sed -i 's/CONFIG_WIFI_MONITOR = n/CONFIG_WIFI_MONITOR = y\nCONFIG_AP_MODE = y/' Makefile || exit 1
 
         sed -i 's/export TopDIR ?= $(shell pwd)/export TopDIR2 ?= $(shell pwd)/' Makefile || exit 1
-        sed -i '/export TopDIR2 ?= $(shell pwd)/a export TopDIR := $(TopDIR2)/drivers/net/wireless/realtek/rtl88x2bu/' Makefile || exit 1
+        sed -i "/export TopDIR2 ?= \$(shell pwd)/a export TopDIR := \$(TopDIR2)/drivers/net/wireless/realtek/${driver_folder}/" Makefile || exit 1
     popd
+}
+
+function build_rtl88x2_driver() {
+    local repo_dir=$1
+    local module=$2
+    local driver_folder=$3
+
+    pushd ${repo_dir}
+        make clean || exit 1
+
+        if [[ "${PLATFORM}" == "jetson" ]]; then
+                export KERNEL_VERSION="4.9.253OpenHD-2.1-tegra"
+                export CROSS_COMPILE=$Tools/gcc-linaro-7.3.1-2018.05-x86_64_aarch64-linux-gnu/bin/aarch64-linux-gnu-
+                make KSRC=${LINUX_DIR}/build -j $J_CORES M=$(pwd) modules || exit 1
+        else
+                make KSRC=${LINUX_DIR} -j $J_CORES M=$(pwd) modules || exit 1
+        fi
+
+        mkdir -p ${PACKAGE_DIR}/lib/modules/${KERNEL_VERSION}/kernel/drivers/net/wireless/realtek/${driver_folder} || exit 1
+        install -p -m 644 ${module} "${PACKAGE_DIR}/lib/modules/${KERNEL_VERSION}/kernel/drivers/net/wireless/realtek/${driver_folder}/" || exit 1
+    popd
+}
+
+function fetch_rtl8812bu_driver() {
+    prepare_rtl88x2_repo rtl88x2bu ${RTL_8812BU_REPO} ${RTL_8812BU_BRANCH} rtl88x2bu
 }
 
 function build_rtl8812bu_driver() {
-    pushd rtl88x2bu
-        make clean || exit 1
-		if [[ "${PLATFORM}" == "jetson" ]]; then
-		export KERNEL_VERSION="4.9.253OpenHD-2.1-tegra"
-		export CROSS_COMPILE=$Tools/gcc-linaro-7.3.1-2018.05-x86_64_aarch64-linux-gnu/bin/aarch64-linux-gnu-
-	        make KSRC=${LINUX_DIR}/build -j $J_CORES M=$(pwd) modules || exit 1
-		else
-        	make KSRC=${LINUX_DIR} -j $J_CORES M=$(pwd) modules || exit 1
-	        fi
-
-        mkdir -p ${PACKAGE_DIR}/lib/modules/${KERNEL_VERSION}/kernel/drivers/net/wireless/realtek/rtl88x2bu || exit 1
-        install -p -m 644 88x2bu_ohd.ko "${PACKAGE_DIR}/lib/modules/${KERNEL_VERSION}/kernel/drivers/net/wireless/realtek/rtl88x2bu/" || exit 1
-        rm -Rf ${PACKAGE_DIR}/lib/modules/${KERNEL_VERSION}/kernel/drivers/net/wireless/realtek/rtl8xxxu
-        echo "removed original realtek driver out of the rpi source"
-    popd
+    build_rtl88x2_driver rtl88x2bu 88x2bu_ohd.ko rtl88x2bu
+    rm -Rf ${PACKAGE_DIR}/lib/modules/${KERNEL_VERSION}/kernel/drivers/net/wireless/realtek/rtl8xxxu
+    echo "removed original realtek driver out of the rpi source"
 }
 
 function fetch_rtl8812cu_driver() {
-
-    if [[ ! "$(ls -A rtl88x2cu)" ]]; then    
-        echo "Download the rtl8812cu driver"
-        git clone ${RTL_8812CU_REPO} || exit 1
-    fi
-
-    pushd rtl88x2cu
-        git fetch || exit 1
-        git reset --hard || exit 1
-        git checkout ${RTL_8812CU_BRANCH} || exit 1
-        git pull || exit 1
-
-        if [[ "${PLATFORM}" == "pi" ]]; then
-            sed -i 's/CONFIG_PLATFORM_I386_PC = y/CONFIG_PLATFORM_I386_PC = n/' Makefile || exit 1
-            sed -i 's/CONFIG_PLATFORM_ARM_RPI = n/CONFIG_PLATFORM_ARM_RPI = y/' Makefile || exit 1
-        fi
-
-        sed -i 's/CONFIG_WIFI_MONITOR = n/CONFIG_WIFI_MONITOR = y\nCONFIG_AP_MODE = y/' Makefile || exit 1
-
-        sed -i 's/export TopDIR ?= $(shell pwd)/export TopDIR2 ?= $(shell pwd)/' Makefile || exit 1
-        sed -i '/export TopDIR2 ?= $(shell pwd)/a export TopDIR := $(TopDIR2)/drivers/net/wireless/realtek/rtl88x2cu/' Makefile || exit 1
-    popd
+    prepare_rtl88x2_repo rtl88x2cu ${RTL_8812CU_REPO} ${RTL_8812CU_BRANCH} rtl88x2cu
 }
 
 function build_rtl8812cu_driver() {
-    pushd rtl88x2cu
-		if [[ "${PLATFORM}" == "jetson" ]]; then
-		export KERNEL_VERSION="4.9.253OpenHD-2.1-tegra"
-		export CROSS_COMPILE=$Tools/gcc-linaro-7.3.1-2018.05-x86_64_aarch64-linux-gnu/bin/aarch64-linux-gnu-
-	        make KSRC=${LINUX_DIR}/build -j $J_CORES M=$(pwd) modules || exit 1
-		else
-        	make KSRC=${LINUX_DIR} -j $J_CORES M=$(pwd) modules || exit 1
-	        fi
-
-        mkdir -p ${PACKAGE_DIR}/lib/modules/${KERNEL_VERSION}/kernel/drivers/net/wireless/realtek/rtl88x2cu || exit 1
-        install -p -m 644 88x2cu_ohd.ko "${PACKAGE_DIR}/lib/modules/${KERNEL_VERSION}/kernel/drivers/net/wireless/realtek/rtl88x2cu/" || exit 1
-    popd
+    build_rtl88x2_driver rtl88x2cu 88x2cu_ohd.ko rtl88x2cu
 }
 
 function fetch_rtl8812eu_driver() {
-
-    if [[ ! "$(ls -A rtl88x2eu)" ]]; then    
-        echo "Download the rtl8812eu driver"
-        git clone ${RTL_8812EU_REPO} || exit 1
-    fi
-
-    pushd rtl88x2eu
-        git fetch || exit 1
-        git reset --hard || exit 1
-        git checkout ${RTL_8812EU_BRANCH} || exit 1
-        git pull || exit 1
-
-        if [[ "${PLATFORM}" == "pi" ]]; then
-            sed -i 's/CONFIG_PLATFORM_I386_PC = y/CONFIG_PLATFORM_I386_PC = n/' Makefile || exit 1
-            sed -i 's/CONFIG_PLATFORM_ARM_RPI = n/CONFIG_PLATFORM_ARM_RPI = y/' Makefile || exit 1
-        fi
-
-        sed -i 's/CONFIG_WIFI_MONITOR = n/CONFIG_WIFI_MONITOR = y\nCONFIG_AP_MODE = y/' Makefile || exit 1
-
-        sed -i 's/export TopDIR ?= $(shell pwd)/export TopDIR2 ?= $(shell pwd)/' Makefile || exit 1
-        sed -i '/export TopDIR2 ?= $(shell pwd)/a export TopDIR := $(TopDIR2)/drivers/net/wireless/realtek/rtl88x2eu/' Makefile || exit 1
-    popd
+    prepare_rtl88x2_repo rtl88x2eu ${RTL_8812EU_REPO} ${RTL_8812EU_BRANCH} rtl88x2eu
 }
 
 function build_rtl8812eu_driver() {
-    pushd rtl88x2eu
-		if [[ "${PLATFORM}" == "jetson" ]]; then
-		export KERNEL_VERSION="4.9.253OpenHD-2.1-tegra"
-		export CROSS_COMPILE=$Tools/gcc-linaro-7.3.1-2018.05-x86_64_aarch64-linux-gnu/bin/aarch64-linux-gnu-
-	        make KSRC=${LINUX_DIR}/build -j $J_CORES M=$(pwd) modules || exit 1
-		else
-        	make KSRC=${LINUX_DIR} -j $J_CORES M=$(pwd) modules || exit 1
-	        fi
-
-        mkdir -p ${PACKAGE_DIR}/lib/modules/${KERNEL_VERSION}/kernel/drivers/net/wireless/realtek/rtl88x2eu || exit 1
-        install -p -m 644 88x2eu_ohd.ko "${PACKAGE_DIR}/lib/modules/${KERNEL_VERSION}/kernel/drivers/net/wireless/realtek/rtl88x2eu/" || exit 1
-    popd
+    build_rtl88x2_driver rtl88x2eu 88x2eu_ohd.ko rtl88x2eu
 }
 # ========================================================== #
 
 function fetch_rtl8188eus_driver() {
 
-    if [[ ! "$(ls -A rtl8188eus)" ]]; then    
+    if [[ ! "$(ls -A rtl8188eus)" ]]; then
         echo "Download the rtl8188eus driver"
         git clone ${RTL_8188EUS_REPO} || exit 1
     fi
@@ -204,13 +158,13 @@ function fetch_rtl8188eus_driver() {
 function build_rtl8188eus_driver() {
     pushd rtl8188eus
         make clean || exit 1
-	if [[ "${PLATFORM}" == "jetson" ]]; then
-		export KERNEL_VERSION="4.9.253OpenHD-2.1-tegra"
-		export CROSS_COMPILE=$Tools/gcc-linaro-7.3.1-2018.05-x86_64_aarch64-linux-gnu/bin/aarch64-linux-gnu-
-	        make KSRC=${LINUX_DIR}/build -j $J_CORES M=$(pwd) modules || exit 1
-		else
-        	make KSRC=${LINUX_DIR} -j $J_CORES M=$(pwd) modules || exit 1
-		fi 
+        if [[ "${PLATFORM}" == "jetson" ]]; then
+                export KERNEL_VERSION="4.9.253OpenHD-2.1-tegra"
+                export CROSS_COMPILE=$Tools/gcc-linaro-7.3.1-2018.05-x86_64_aarch64-linux-gnu/bin/aarch64-linux-gnu-
+                make KSRC=${LINUX_DIR}/build -j $J_CORES M=$(pwd) modules || exit 1
+                else
+                make KSRC=${LINUX_DIR} -j $J_CORES M=$(pwd) modules || exit 1
+                fi
         mkdir -p ${PACKAGE_DIR}/lib/modules/${KERNEL_VERSION}/kernel/drivers/net/wireless/realtek/rtl8188eus || exit 1
         install -p -m 644 8188eu.ko "${PACKAGE_DIR}/lib/modules/${KERNEL_VERSION}/kernel/drivers/net/wireless/realtek/rtl8188eus/" || exit 1
     popd


### PR DESCRIPTION
## Summary
- propagate CCACHE environment and wrapper setup through the workflow and build scripts
- refactor rtl88x2 driver helpers and re-enable rtl8812cu fetch/build steps
- set default CCACHE settings for consistent kernel and module compilation

## Testing
- bash -n build.sh scripts/*.sh


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69232c7a5324832fbeed89356813992d)